### PR TITLE
Updated default report templates

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,3 +1,9 @@
+1.0.2 (unreleased)
+------------------
+
+- #6: Updated default report templates
+
+
 1.0.1 (2018-06-23)
 ------------------
 

--- a/src/senaite/impress/templates/reports/Default.pt
+++ b/src/senaite/impress/templates/reports/Default.pt
@@ -7,7 +7,7 @@
   <tal:css define="laboratory view/laboratory;">
     <style type="text/css">
      html, body { font-size: 1em; }
-     h1 { font-size: 160%; }
+     h1 { font-size: 140%; }
      h2 { font-size: 120%; }
      .colon-after:after { content: ":"; }
      table.noborder td { border: none; }
@@ -34,24 +34,12 @@
   <!-- HEADER -->
   <tal:render condition="python:True">
     <div class="row section-header">
-      <div class="col-sm-6">
+      <div class="col-sm-12">
         <div class="text-left">
           <a tal:attributes="href view/portal_url">
             <img style="max-height: 100px"
                  tal:attributes="src python:view.get_resource_url('logo_print.png')"/>
           </a>
-        </div>
-      </div>
-      <div class="col-sm-6 pt-2">
-        <!-- Barcode -->
-        <div class="text-center float-right barcode-container">
-          <div class="barcode"
-               data-code="code128"
-               data-showHRI="true"
-               data-barHeight="15"
-               data-addQuietZone="true"
-               tal:attributes="data-id model/getId">
-          </div>
         </div>
       </div>
     </div>
@@ -65,7 +53,7 @@
   <div class="row section-info">
     <div class="col-sm-12">
       <!-- Client Info -->
-      <table class="table table-sm">
+      <table class="table table-sm table-condensed">
         <colgroup>
           <!-- Client Address -->
           <col style="width: 40%;">
@@ -183,8 +171,20 @@
                       spec python:publication_specification or specification;">
     <div class="row section-summary">
       <div class="col col-sm-12">
+
+        <!-- Barcode -->
+        <div class="text-center float-right barcode-container">
+          <div class="barcode"
+               data-code="code128"
+               data-showHRI="true"
+               data-barHeight="15"
+               data-addQuietZone="true"
+               tal:attributes="data-id model/getId">
+          </div>
+        </div>
+
         <h1 i18n:translate="">Summary</h1>
-        <table class="table table-sm">
+        <table class="table table-sm table-condensed">
           <tr>
             <td style="width:20%" class="label" i18n:translate="">Request ID</td>
             <td>
@@ -274,14 +274,12 @@
         <tal:poc define="analyses_by_poc python:view.get_analyses_by_poc(model);"
                  repeat="poc analyses_by_poc">
 
-          <h4 tal:content="python:view.points_of_capture.get(poc)"></h4>
-
           <!-- Analysis Category -->
           <tal:categories_in_poc define="categories_by_poc python:view.get_categories_by_poc(model)"
                                  repeat="category python:view.sort_items(categories_by_poc.get(poc))">
 
             <!-- Analysis in POC and Category -->
-            <table class="table table-sm">
+            <table class="table table-sm table-condensed">
               <colgroup>
                 <!-- Category -->
                 <col style="width: 40%;">
@@ -295,7 +293,7 @@
                 <col style="width: 5%">
               </colgroup>
               <thead>
-                <tr>
+                <tr class="small">
                   <th class="analysis">
                     <span class="font-weight-bold" tal:content="category/Title">Category</span>
                   </th>
@@ -378,7 +376,7 @@
         <h1 i18n:translate="">Results interpretation</h1>
 
         <tal:ri repeat="ri ris">
-          <h4 tal:content="ri/title|nothing">Department</h4>
+          <h2 tal:condition="ri/richtext|nothing" tal:content="ri/title|nothing">Department</h2>
           <div class="text-info" tal:content="structure ri/richtext|nothing"></div>
         </tal:ri>
       </div>
@@ -469,7 +467,7 @@
     <div class="row section-signatures">
       <div class="col-sm-12">
         <h1 i18n:translate="">Responsibles</h1>
-        <table class="table table-sm">
+        <table class="table table-sm table-condensed">
           <tr>
             <tal:manager repeat="manager python:model.managers">
               <td style="border:none">

--- a/src/senaite/impress/templates/reports/MultiDefault.pt
+++ b/src/senaite/impress/templates/reports/MultiDefault.pt
@@ -7,7 +7,7 @@
   <tal:css define="laboratory view/laboratory;">
     <style type="text/css">
      html, body { font-size: 1em; }
-     h1 { font-size: 160%; }
+     h1 { font-size: 140%; }
      h2 { font-size: 120%; }
      .colon-after:after { content: ":"; }
      table.noborder td { border: none; }
@@ -60,7 +60,7 @@
     <div class="row section-info">
       <div class="col-sm-12">
         <!-- Client Info -->
-        <table class="table table-sm">
+        <table class="table table-sm table-condensed">
           <colgroup>
             <!-- Client Address -->
             <col style="width: 40%;">
@@ -155,7 +155,7 @@
   <tal:render condition="python:True">
     <tal:model repeat="model collection">
       <div class="alert alert-danger" tal:condition="model/is_invalid">
-        <h4 class="alert-heading"><span tal:replace="model/getId"/></h4>
+        <h2 class="alert-heading"><span tal:replace="model/getId"/></h2>
         <div i18n:translate="">This Analysis Request has been invalidated due to erroneously published results</div>
         <tal:invalidreport tal:define="child model/ChildAnalysisRequest"
                            tal:condition="child">
@@ -166,7 +166,7 @@
       </div>
 
       <div class="alert alert-info" tal:condition="model/is_provisional">
-        <h4 class="alert-heading"><span tal:replace="model/getId"/></h4>
+        <h2 class="alert-heading"><span tal:replace="model/getId"/></h2>
         <div i18n:translate="">Provisional report</div>
       </div>
     </tal:model>
@@ -199,7 +199,7 @@
 
         <h1 i18n:translate="">Summary</h1>
 
-        <table class="table table-sm">
+        <table class="table table-sm table-condensed">
           <tr>
             <td style="width:20%" class="label" i18n:translate="">Request ID</td>
             <td>
@@ -291,14 +291,12 @@
           <tal:poc define="analyses_by_poc python:view.get_analyses_by_poc(model);"
                    tal:repeat="poc analyses_by_poc">
 
-            <h4 tal:content="python:view.points_of_capture.get(poc)"></h4>
-
             <!-- Analysis Category -->
             <tal:categories_in_poc define="categories_by_poc python:view.get_categories_by_poc(model)"
                                    repeat="category python:view.sort_items(categories_by_poc.get(poc))">
 
               <!-- Analysis in POC and Category -->
-              <table class="table table-sm">
+              <table class="table table-sm table-condensed">
                 <colgroup>
                   <!-- Category -->
                   <col style="width: 40%;">
@@ -312,7 +310,7 @@
                   <col style="width: 5%">
                 </colgroup>
                 <thead>
-                  <tr>
+                  <tr class="small">
                     <th class="analysis">
                       <span tal:content="category/Title">Category</span>
                     </th>
@@ -397,10 +395,10 @@
       <div class="row section-resultsinterpretation"
            tal:define="ris python:model.get_resultsinterpretation()"
            tal:condition="ris">
-        <h1 i18n:translate>Results Interpretation for <span tal:replace="model/getId"/></h1>
         <div class="col-sm-12" tal:condition="ris">
+          <h1 i18n:translate>Results Interpretation for <span tal:replace="model/getId"/></h1>
           <tal:ri repeat="ri ris">
-            <h4 tal:content="ri/title|nothing">Department</h4>
+            <h2 tal:condition="ri/richtext|nothing" tal:content="ri/title|nothing">Department</h2>
             <div class="text-info" tal:content="structure ri/richtext|nothing"></div>
           </tal:ri>
         </div>
@@ -413,8 +411,8 @@
     <tal:model repeat="model collection">
       <tal:qc define="qcanalyses python:model.getQCAnalyses(['verified', 'published']);">
         <div class="row section-results" tal:condition="qcanalyses">
-          <h2 i18n:translate>QC Results for <span tal:replace="model/getId"/></h2>
           <div class="col col-sm-12">
+            <h2 i18n:translate>QC Results for <span tal:replace="model/getId"/></h2>
             <h1 i18n:translate="">QC Results</h1>
           </div>
         </div>
@@ -442,55 +440,58 @@
                                   an_attachments python:model.get_sorted_an_attachments('r')"
                       tal:condition="python: ar_attachments or an_attachments">
 
-        <h4 i18n:translate="">
-          Attachments for <span tal:replace="model/getId"/>
-        </h4>
+        <div class="section-attachments">
+          <h2 i18n:translate="">Attachments</h2>
 
-        <!-- AR ATTACHMENTS -->
-        <div class="row section-an-attachments" tal:condition="ar_attachments">
-          <div class="col-sm-12">
-            <table class="table">
-              <colgroup>
-                <col tal:attributes="style python:'width:{}%'.format(100/attachments_per_row)">
-              </colgroup>
-              <tr tal:repeat="chunk python:view.group_into_chunks(ar_attachments, attachments_per_row)">
-                <td class="align-bottom"
-                    style="border:none;padding-left:0;"
-                    tal:repeat="attachment chunk">
-                  <img class="img-fluid"
-                       style="width:100%;"
-                       tal:attributes="src string:${attachment/absolute_url}/AttachmentFile"/>
-                  <div class="text-secondary">
-                    <span tal:content="attachment/AttachmentKeys"/>
-                  </div>
-                </td>
-              </tr>
-            </table>
+          <!-- AR ATTACHMENTS -->
+          <div class="row section-an-attachments" tal:condition="ar_attachments">
+            <div class="col-sm-12">
+              <table class="table">
+                <colgroup>
+                  <col tal:attributes="style python:'width:{}%'.format(100/attachments_per_row)">
+                </colgroup>
+                <tr tal:repeat="chunk python:view.group_into_chunks(ar_attachments, attachments_per_row)">
+                  <td class="align-bottom"
+                      style="border:none;padding-left:0;"
+                      tal:repeat="attachment chunk">
+                    <img class="img-fluid"
+                         style="width:100%;"
+                         tal:attributes="src string:${attachment/absolute_url}/AttachmentFile"/>
+                    <div class="text-secondary">
+                      <span tal:content="attachment/AttachmentKeys"/>
+                    </div>
+                  </td>
+                </tr>
+              </table>
+            </div>
           </div>
-        </div>
+          <!-- /AR ATTACHMENTS -->
 
-        <!-- AN ATTACHMENTS -->
-        <div class="row section-an-attachments" tal:condition="an_attachments">
-          <div class="col-sm-12">
-            <table class="table">
-              <colgroup>
-                <col tal:attributes="style python:'width:{}%'.format(100/attachments_per_row)">
-              </colgroup>
-              <tr tal:repeat="chunk python:view.group_into_chunks(an_attachments, attachments_per_row)">
-                <td class="align-bottom"
-                    style="border:none;padding-left:0;"
-                    tal:repeat="attachment chunk">
-                  <img class="img-fluid"
-                       style="width:100%;"
-                       tal:attributes="src python:attachment[1].absolute_url() + '/AttachmentFile'"/>
-                  <div class="text-secondary">
-                    <span tal:content="python:attachment[1].title"/>:
-                    <span tal:content="python:attachment[1].AttachmentKeys"/>
-                  </div>
-                </td>
-              </tr>
-            </table>
+          <!-- AN ATTACHMENTS -->
+          <div class="row section-an-attachments" tal:condition="an_attachments">
+            <div class="col-sm-12">
+              <table class="table">
+                <colgroup>
+                  <col tal:attributes="style python:'width:{}%'.format(100/attachments_per_row)">
+                </colgroup>
+                <tr tal:repeat="chunk python:view.group_into_chunks(an_attachments, attachments_per_row)">
+                  <td class="align-bottom"
+                      style="border:none;padding-left:0;"
+                      tal:repeat="attachment chunk">
+                    <img class="img-fluid"
+                         style="width:100%;"
+                         tal:attributes="src python:attachment[1].absolute_url() + '/AttachmentFile'"/>
+                    <div class="text-secondary">
+                      <span tal:content="python:attachment[1].title"/>:
+                      <span tal:content="python:attachment[1].AttachmentKeys"/>
+                    </div>
+                  </td>
+                </tr>
+              </table>
+            </div>
           </div>
+          <!-- /AN ATTACHMENTS -->
+
         </div>
       </tal:attachment>
     </tal:model>
@@ -502,7 +503,7 @@
       <div class="row section-signatures">
         <div class="col-sm-12">
           <h1 i18n:translate="">Responsibles</h1>
-          <table class="table table-sm">
+          <table class="table table-sm table-condensed">
             <tr>
               <tal:manager repeat="manager managers">
                 <td style="border:none">

--- a/src/senaite/impress/templates/reports/MultiDefaultByColumn.pt
+++ b/src/senaite/impress/templates/reports/MultiDefaultByColumn.pt
@@ -7,7 +7,7 @@
   <tal:css define="laboratory view/laboratory;">
     <style type="text/css">
      html, body { font-size: 1em; }
-     h1 { font-size: 160%; }
+     h1 { font-size: 140%; }
      h2 { font-size: 120%; }
      .colon-after:after { content: ":"; }
      table.noborder td { border: none; }
@@ -51,7 +51,10 @@
   </tal:render>
 
   <!-- INFO -->
-  <tal:render condition="python:True">
+  <tal:render condition="python:len(collection)>0"
+              define="primarymodel python:collection[0];
+                      samples python:map(lambda m: m.Sample, collection);">
+
     <div class="row section-info">
       <div class="col-sm-12 py-4 small">
         <!-- Client Info -->
@@ -63,7 +66,7 @@
           <tr>
             <td class="align-top">
               <!-- Left Table -->
-              <table class="table table-sm mr-1">
+              <table class="table table-sm table-condensed mr-1">
                 <!-- Client Name(s) -->
                 <tr>
                   <td class="label" i18n:translate="">Client</td>
@@ -109,12 +112,6 @@
                     </tal:by_client_sid>
                   </td>
                 </tr>
-              </table>
-            </td>
-            <td class="align-top">
-              <!-- Right Table -->
-              <table class="table table-sm ml-1"
-                     tal:define="samples python:map(lambda m: m.Sample, collection)">
                 <!-- Sample Type -->
                 <tr>
                   <td class="label" i18n:translate="">Sample Type</td>
@@ -146,6 +143,58 @@
                 </tr>
               </table>
             </td>
+            <td class="align-top">
+              <!-- Right Table -->
+              <table class="table table-sm table-condensed ml-1"
+                     tal:define="laboratory python:view.laboratory;">
+                <tr>
+                  <td>
+                    <!-- Laboratory Info -->
+                    <address class="laboratory-address text-right">
+                      <div class="lab-title font-weight-bold">
+                        <div tal:replace="laboratory/title|nothing"/>
+                      </div>
+                      <div class="lab-supervisor" tal:condition="laboratory/Supervisor">
+                        <span i18n:translate="">Supervisor</span>:
+                        <div tal:replace="laboratory/Supervisor/Fullname|nothing"/>
+                      </div>
+                      <div class="lab-address">
+                        <div class="lab-street">
+                          <div tal:replace="laboratory/PostalAddress/address|nothing"></div>
+                        </div>
+                        <span class="lab-zip">
+                          <div tal:replace="laboratory/PostalAddress/zip|nothing"></div>
+                        </span>
+                        <span class="lab-city">
+                          <div tal:replace="laboratory/PostalAddress/city|nothing"></div>
+                        </span>
+                        <div class="lab-country">
+                          <div tal:replace="laboratory/PostalAddress/country|nothing"></div>
+                        </div>
+                      </div>
+                      <div class="lab-url">
+                        <a tal:attributes="href laboratory/LabURL"
+                           tal:content="laboratory/LabURL"></a>
+                      </div>
+                    </address>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="text-right">
+                    <!-- Barcode -->
+                    <div tal:repeat="model collection" class="text-center float-right barcode-container mt-2">
+                      <div class="barcode"
+                           data-code="code128"
+                           data-showHRI="true"
+                           data-barHeight="15"
+                           data-addQuietZone="false"
+                           tal:attributes="data-id model/getId">
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              </table>
+            </td>
           </tr>
         </table>
       </div>
@@ -156,7 +205,7 @@
   <tal:render condition="python:True">
     <tal:model repeat="model collection">
       <div class="alert alert-danger" tal:condition="model/is_invalid">
-        <h4 class="alert-heading"><span tal:replace="model/getId"/></h4>
+        <h2 class="alert-heading"><span tal:replace="model/getId"/></h2>
         <div i18n:translate="">This Analysis Request has been invalidated due to erroneously published results</div>
         <tal:invalidreport tal:define="child model/ChildAnalysisRequest"
                            tal:condition="child">
@@ -167,7 +216,7 @@
       </div>
 
       <div class="alert alert-info" tal:condition="model/is_provisional">
-        <h4 class="alert-heading"><span tal:replace="model/getId"/></h4>
+        <h2 class="alert-heading"><span tal:replace="model/getId"/></h2>
         <div i18n:translate="">Provisional report</div>
       </div>
     </tal:model>
@@ -183,7 +232,7 @@
 
         <!-- Point of Captures -->
         <tal:poc tal:repeat="poc analyses_by_poc">
-          <h4 tal:content="python:view.points_of_capture.get(poc)"></h4>
+          <h2 tal:content="python:view.points_of_capture.get(poc)"></h2>
 
           <!-- Results table per PoC -->
           <table class="table table-sm table-condensed small">
@@ -191,7 +240,7 @@
               <tr>
                 <th></th>
                 <tal:ar repeat="model collection">
-                  <th colspan="2" class="font-weight-normal text-right">
+                  <th colspan="2" class="font-weight-normal text-center">
                     <div class="text-primary"
                          tal:content="model/getId"/>
                   </th>
@@ -261,7 +310,7 @@
           <h1 i18n:translate>Results Interpretation for <span tal:replace="model/getId"/></h1>
           <div tal:condition="ris">
             <tal:ri repeat="ri ris">
-              <h4 tal:content="ri/title|nothing">Department</h4>
+              <h2 tal:condition="ri/richtext|nothing" tal:content="ri/title|nothing">Department</h2>
               <div class="text-info" tal:content="structure ri/richtext|nothing"></div>
             </tal:ri>
           </div>
@@ -306,9 +355,9 @@
                                   an_attachments python:model.get_sorted_an_attachments('r')"
                       tal:condition="python: ar_attachments or an_attachments">
 
-        <h4 i18n:translate="">
+        <h2 i18n:translate="">
           Attachments for <span tal:replace="model/getId"/>
-        </h4>
+        </h2>
 
         <!-- AR ATTACHMENTS -->
         <div class="row section-an-attachments" tal:condition="ar_attachments">
@@ -366,7 +415,7 @@
       <div class="row section-signatures">
         <div class="col-sm-12">
           <h1 i18n:translate="">Responsibles</h1>
-          <table class="table table-sm">
+          <table class="table table-sm table-condensed">
             <tr>
               <tal:manager repeat="manager managers">
                 <td style="border:none">


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR updates the style and markup of the default templates.
It also fixes a rendering problem with the multi-default template
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
