### PR TITLE
Better Print CSS

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.0.2 (unreleased)
 ------------------
 
+- #8: Better Print CSS
 - #7: Correct margin calculation
 - #6: Updated default report templates
 

--- a/src/senaite/impress/static/css/print.css
+++ b/src/senaite/impress/static/css/print.css
@@ -9,8 +9,9 @@
 
 @media print {
   .noprint { display: none; }
-  .report { page-break-after: always; }
+  .report { page-break-after: always; overflow: visible; }
   h1, h2, h3, h4, h5 { page-break-after: avoid; }
+  div.row { page-break-inside: avoid; }
 }
 
 /** For screen preview **/


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR updates the default `print.css`, so that page breaks are avoided within rows and contents are allowed to overflow over the calculated content size.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
