### PR TITLE
Added upgrade-step machinery

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.0.3 (unreleased)
 ------------------
 
+- #12: Added upgrade-step machinery
 - #11: Refactored to ReportModel -> SuperModel
 
 

--- a/src/senaite/impress/configure.zcml
+++ b/src/senaite/impress/configure.zcml
@@ -21,6 +21,9 @@
   <!-- AR specific Reports -->
   <include package=".analysisrequest" />
 
+  <!-- Upgrade Steps -->
+  <include package=".upgrades" />
+
   <!-- Publish Controller View
 
        TODO: Rename to `publish` for drop-in replacement as soon as this package

--- a/src/senaite/impress/profiles/default/metadata.xml
+++ b/src/senaite/impress/profiles/default/metadata.xml
@@ -1,3 +1,3 @@
 <metadata>
-  <version>1.0.3</version>
+  <version>1000</version>
 </metadata>

--- a/src/senaite/impress/profiles/uninstall/metadata.xml
+++ b/src/senaite/impress/profiles/uninstall/metadata.xml
@@ -1,3 +1,3 @@
 <metadata>
-  <version>1.0.3</version>
+  <version>1000</version>
 </metadata>

--- a/src/senaite/impress/upgrades/__init__.py
+++ b/src/senaite/impress/upgrades/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.IMPRESS
+#
+# Copyright 2018 by it's authors.

--- a/src/senaite/impress/upgrades/configure.zcml
+++ b/src/senaite/impress/upgrades/configure.zcml
@@ -1,0 +1,15 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    i18n_domain="senaite.impress">
+
+  <genericsetup:upgradeStep
+      title="Upgrade SENAITE IMPRESS"
+      description="Initial Profile"
+      sortkey="1"
+      source="*"
+      destination="1000"
+      handler="senaite.impress.upgrades.handlers.to_1000"
+      profile="senaite.impress:default" />
+
+</configure>

--- a/src/senaite/impress/upgrades/handlers.py
+++ b/src/senaite/impress/upgrades/handlers.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.IMPRESS
+#
+# Copyright 2018 by it's authors.
+
+from senaite.impress import logger
+
+PROFILE_ID = "profile-senaite.impress:default"
+
+
+def to_1000(portal_setup):
+    """Initial version to 1000
+
+    :param portal_setup: The portal_setup tool
+    """
+
+    logger.info("Run all import steps from SENAITE IMPRESS ...")
+    portal_setup.runAllImportStepsFromProfile(PROFILE_ID)
+    logger.info("Run all import steps from SENAITE IMPRESS [DONE]")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds the upgrade step machinery to `senaite.impress` and starts over with the profile version 1000.

## Current behavior before PR

No upgrade step machinery integrated

## Desired behavior after PR is merged

Upgrade step machinery integrated

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
