### PR TITLE
Removed generic column CSS style

### DIFF
--- a/src/senaite/impress/static/css/bootstrap-print.css
+++ b/src/senaite/impress/static/css/bootstrap-print.css
@@ -1,10 +1,6 @@
 /* WeasyPrint Bootstrap v4 print fixtures */
 
 @media print {
-  .col {
-    width: auto;
-    float: left;
-  }
   .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12,
   .col-sm-1, .col-sm-2, .col-sm-3, .col-sm-4, .col-sm-5, .col-sm-6, .col-sm-7, .col-sm-8, .col-sm-9, .col-sm-10, .col-sm-11, .col-sm-12,
   .col-md-1, .col-md-2, .col-md-3, .col-md-4, .col-md-5, .col-md-6, .col-md-7, .col-md-8, .col-md-9, .col-md-10, .col-md-11, .col-md-12,


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR removes the CSS style for `.col` which was introduced in #13 because of side-effects with  existing reports
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
