### PR TITLE
Handle commas in recipient email name better

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.0.3 (unreleased)
 ------------------
 
+- #15: Handle commas in recipient email name better
 - #13: Fix bootstrap columns CSS for WeasyPrint
 - #12: Added upgrade-step machinery
 - #11: Refactored to ReportModel -> SuperModel

--- a/src/senaite/impress/emailview.py
+++ b/src/senaite/impress/emailview.py
@@ -194,7 +194,7 @@ class EmailView(BrowserView):
     def parse_email(self, email):
         """parse an email to an unicode name, email tuple
         """
-        splitted = safe_unicode(email).split(",")
+        splitted = safe_unicode(email).rsplit(",", 1)
         if len(splitted) == 1:
             return (False, splitted[0])
         elif len(splitted) == 2:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR handles commas in the recipient names better for email usage

## Current behavior before PR

commas in given- or surname were incorrect splitted

## Desired behavior after PR is merged

commas in given- or surname are correctly splitted

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
