### PR TITLE
Fix alert section overlapping of the header section

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.0.3 (unreleased)
 ------------------
 
+- #17: Fix alert section overlapping of the header section
 - #16: Fix unicode error in sort method
 - #15: Handle commas in recipient email name better
 - #13: Fix bootstrap columns CSS for WeasyPrint

--- a/src/senaite/impress/templates/reports/Default.pt
+++ b/src/senaite/impress/templates/reports/Default.pt
@@ -146,17 +146,21 @@
 
   <!-- ALERTS -->
   <tal:render condition="python:True">
-    <div class="alert alert-danger" tal:condition="model/is_invalid">
-      <div i18n:translate="">This Analysis Request has been invalidated due to erroneously published results</div>
-      <tal:invalidreport tal:define="child model/ChildAnalysisRequest"
-                         tal:condition="child">
-        <span i18n:translate="">This Analysis request has been replaced by</span>
-        <a tal:attributes="href child/absolute_url"
-           tal:content="child/getId"></a>
-      </tal:invalidreport>
-    </div>
-    <div class="alert alert-info" tal:condition="model/is_provisional">
-      <div i18n:translate="">Provisional report</div>
+    <div class="row section-alerts">
+      <div class="col col-sm-12">
+        <div class="alert alert-danger" tal:condition="model/is_invalid">
+          <div i18n:translate="">This Analysis Request has been invalidated due to erroneously published results</div>
+          <tal:invalidreport tal:define="child model/ChildAnalysisRequest"
+                             tal:condition="child">
+            <span i18n:translate="">This Analysis request has been replaced by</span>
+            <a tal:attributes="href child/absolute_url"
+               tal:content="child/getId"></a>
+          </tal:invalidreport>
+        </div>
+        <div class="alert alert-info" tal:condition="model/is_provisional">
+          <div i18n:translate="">Provisional report</div>
+        </div>
+      </div>
     </div>
   </tal:render>
 

--- a/src/senaite/impress/templates/reports/MultiDefault.pt
+++ b/src/senaite/impress/templates/reports/MultiDefault.pt
@@ -153,23 +153,27 @@
 
   <!-- ALERTS -->
   <tal:render condition="python:True">
-    <tal:model repeat="model collection">
-      <div class="alert alert-danger" tal:condition="model/is_invalid">
-        <h2 class="alert-heading"><span tal:replace="model/getId"/></h2>
-        <div i18n:translate="">This Analysis Request has been invalidated due to erroneously published results</div>
-        <tal:invalidreport tal:define="child model/ChildAnalysisRequest"
-                           tal:condition="child">
-          <span i18n:translate="">This Analysis request has been replaced by</span>
-          <a tal:attributes="href child/absolute_url"
-             tal:content="child/getId"></a>
-        </tal:invalidreport>
-      </div>
+    <div class="row section-alerts">
+      <div class="col col-sm-12">
+        <tal:model repeat="model collection">
+          <div class="alert alert-danger" tal:condition="model/is_invalid">
+            <h2 class="alert-heading"><span tal:replace="model/getId"/></h2>
+            <div i18n:translate="">This Analysis Request has been invalidated due to erroneously published results</div>
+            <tal:invalidreport tal:define="child model/ChildAnalysisRequest"
+                               tal:condition="child">
+              <span i18n:translate="">This Analysis request has been replaced by</span>
+              <a tal:attributes="href child/absolute_url"
+                 tal:content="child/getId"></a>
+            </tal:invalidreport>
+          </div>
 
-      <div class="alert alert-info" tal:condition="model/is_provisional">
-        <h2 class="alert-heading"><span tal:replace="model/getId"/></h2>
-        <div i18n:translate="">Provisional report</div>
+          <div class="alert alert-info" tal:condition="model/is_provisional">
+            <h2 class="alert-heading"><span tal:replace="model/getId"/></h2>
+            <div i18n:translate="">Provisional report</div>
+          </div>
+        </tal:model>
       </div>
-    </tal:model>
+    </div>
   </tal:render>
 
   <!-- SUMMARY (First AR is primary for the data) -->

--- a/src/senaite/impress/templates/reports/MultiDefaultByColumn.pt
+++ b/src/senaite/impress/templates/reports/MultiDefaultByColumn.pt
@@ -203,23 +203,27 @@
 
   <!-- ALERTS -->
   <tal:render condition="python:True">
-    <tal:model repeat="model collection">
-      <div class="alert alert-danger" tal:condition="model/is_invalid">
-        <h2 class="alert-heading"><span tal:replace="model/getId"/></h2>
-        <div i18n:translate="">This Analysis Request has been invalidated due to erroneously published results</div>
-        <tal:invalidreport tal:define="child model/ChildAnalysisRequest"
-                           tal:condition="child">
-          <span i18n:translate="">This Analysis request has been replaced by</span>
-          <a tal:attributes="href child/absolute_url"
-             tal:content="child/getId"></a>
-        </tal:invalidreport>
-      </div>
+    <div class="row section-alerts">
+      <div class="col col-sm-12">
+        <tal:model repeat="model collection">
+          <div class="alert alert-danger" tal:condition="model/is_invalid">
+            <h2 class="alert-heading"><span tal:replace="model/getId"/></h2>
+            <div i18n:translate="">This Analysis Request has been invalidated due to erroneously published results</div>
+            <tal:invalidreport tal:define="child model/ChildAnalysisRequest"
+                               tal:condition="child">
+              <span i18n:translate="">This Analysis request has been replaced by</span>
+              <a tal:attributes="href child/absolute_url"
+                 tal:content="child/getId"></a>
+            </tal:invalidreport>
+          </div>
 
-      <div class="alert alert-info" tal:condition="model/is_provisional">
-        <h2 class="alert-heading"><span tal:replace="model/getId"/></h2>
-        <div i18n:translate="">Provisional report</div>
+          <div class="alert alert-info" tal:condition="model/is_provisional">
+            <h2 class="alert-heading"><span tal:replace="model/getId"/></h2>
+            <div i18n:translate="">Provisional report</div>
+          </div>
+        </tal:model>
       </div>
-    </tal:model>
+    </div>
   </tal:render>
 
   <!-- RESULTS -->


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds special HTML markup for the report alert section 

## Current behavior before PR

Alerts overlapped the header section

## Desired behavior after PR is merged

Alerts do not overlap header section

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
