### PR TITLE
Fixed barcode rendering in multi-colum report

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.0.3 (unreleased)
 ------------------
 
+- #18: Fixed barcode rendering in multi-colum report
 - #17: Fix alert section overlapping of the header section
 - #16: Fix unicode error in sort method
 - #15: Handle commas in recipient email name better

--- a/src/senaite/impress/templates/reports/MultiDefaultByColumn.pt
+++ b/src/senaite/impress/templates/reports/MultiDefaultByColumn.pt
@@ -182,13 +182,15 @@
                 <tr>
                   <td class="text-right">
                     <!-- Barcode -->
-                    <div tal:repeat="model collection" class="text-center float-right barcode-container mt-2">
-                      <div class="barcode"
-                           data-code="code128"
-                           data-showHRI="true"
-                           data-barHeight="15"
-                           data-addQuietZone="false"
-                           tal:attributes="data-id model/getId">
+                    <div tal:repeat="model collection" class="barcode-container mt-2">
+                      <div class="clearfix">
+                        <div class="barcode float-right"
+                             data-code="code128"
+                             data-showHRI="true"
+                             data-barHeight="15"
+                             data-addQuietZone="false"
+                             tal:attributes="data-id model/getId">
+                        </div>
                       </div>
                     </div>
                   </td>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the rendering of barcodes in the multi column report

## Current behavior before PR

Barcodes are displayed next to each other without spaces in between

## Desired behavior after PR is merged

Barcodes are displayed below each other and aligned right

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
