### PR TITLE
Improved email template

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.0.3 (unreleased)
 ------------------
 
+- #21: Improved email template
 - #19: Allow additional attachments in publication email
 - #18: Fixed barcode rendering in multi-colum report
 - #17: Fix alert section overlapping of the header section

--- a/src/senaite/impress/templates/email_template.pt
+++ b/src/senaite/impress/templates/email_template.pt
@@ -2,23 +2,29 @@
   tal:define="client_name python:view.client_name;
               laboratory python:context.bika_setup.laboratory"
   i18n:domain="senaite.impress">
-  <tal:p i18n:translate="">
-    Thank you for your analysis request.
-  </tal:p>
 
-  <tal:p i18n:translate="">
-    Please find attached the analysis result(s) for
-    <tal:client i18n:name="client_name" content="client_name"/>
-  </tal:p>
+<tal:p i18n:translate="">
+Thank you for your analysis request.
+</tal:p>
 
-  <tal:p i18n:translate="">
-    This report was sent to the following contacts:
-  </tal:p>
+<tal:p i18n:translate="">
+Please find attached the analysis result(s) for
+<tal:client i18n:name="client_name" content="client_name"/>
+</tal:p>
 
-  $recipients
+<tal:p i18n:translate="">
+This report was sent to the following contacts:
+</tal:p>
 
-  <tal:p i18n:translate="">
-    With best regards
-  </tal:p>
-  <tal:laboratory tal:replace="python:laboratory.getName() or 'SENAITE LIMS'"/>
+$recipients
+
+<tal:p i18n:translate="">
+With best regards
+</tal:p>
+<tal:laboratory tal:replace="python:laboratory.getName() or 'SENAITE LIMS'"/>
+
+<tal:p i18n:translate="">
+*** This is an automatically generated email, please do not reply to this message. ***
+</tal:p>
+
 </tal:email_template>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR removes the leading whitespaces of the email template and added the sentence:

`*** This is an automatically generated email, please do not reply to this message. ***`


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
