### PR TITLE
Control individual report generation for multi-report PDFs

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.0.3 (unreleased)
 ------------------
 
+- #24: Control individual report generation for multi-report PDFs
 - #23: Fixed multi client report handling
 - #21: Improved email template
 - #19: Allow additional attachments in publication email

--- a/src/senaite/impress/ajax.py
+++ b/src/senaite/impress/ajax.py
@@ -188,6 +188,8 @@ class AjaxPublishView(PublishView):
         template = data.get("template")
         orientation = data.get("orientation", "portrait")
         timestamp = DateTime().ISO8601()
+        is_multi_template = self.is_multi_template(template)
+        store_individually = self.store_multireports_individually()
 
         # Generate the print CSS with the set format/orientation
         css = self.get_print_css(
@@ -238,6 +240,10 @@ class AjaxPublishView(PublishView):
                     })
                 reports.append(report)
                 client_url = api.get_url(obj.getClient())
+
+                # generate report only for the primary object
+                if is_multi_template and not store_individually:
+                    break
 
             # remember the generated report UIDs for this iteration
             report_uids = map(api.get_uid, reports)

--- a/src/senaite/impress/controlpanel.py
+++ b/src/senaite/impress/controlpanel.py
@@ -35,6 +35,15 @@ class IImpressControlPanel(Interface):
         required=True,
     )
 
+    store_multireports_individually = schema.Bool(
+        title=_(u"Store Multi-Report PDFs Individually"),
+        description=_("Store generated multi-report PDFs individually. "
+                      "Turn off to store the multi-report PDF only for the "
+                      "primary item of the report."),
+        default=True,
+        required=False,
+    )
+
     max_email_size = schema.Float(
         title=_(u"Maximum Email Size in MB"),
         default=10.0,

--- a/src/senaite/impress/publishview.py
+++ b/src/senaite/impress/publishview.py
@@ -252,6 +252,13 @@ class PublishView(BrowserView):
             return default
         return orientation
 
+    def store_multireports_individually(self):
+        """Returns the configured setting from the registry
+        """
+        store_individually = api.get_registry_record(
+            "senaite.impress.store_multireports_individually")
+        return store_individually
+
     def get_report_template(self, template=None):
         """Returns the path of report template
         """


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR introduces a setting to control whether a multi-report PDF should be generated for all all the contained ARs or only for the primary AR.

## Current behavior before PR

Multi report PDFs get stored for all contained ARs individually.

## Desired behavior after PR is merged

Multi report PDFs get stored either for all contained ARs individually, or only for the primary AR of the multi-report only.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
