### PR TITLE
Refactored Report Adapters to Multi Adapters

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.0.3 (unreleased)
 ------------------
 
+- #27: Refactored Report Adapters to Multi Adapters
 - #25: Added controlpanel descriptions
 - #24: Control individual report generation for multi-report PDFs
 - #23: Fixed multi client report handling

--- a/src/senaite/impress/analysisrequest/configure.zcml
+++ b/src/senaite/impress/analysisrequest/configure.zcml
@@ -6,7 +6,8 @@
 
   <!-- View for Single Reports -->
   <adapter
-      for="*"
+      for="zope.interface.Interface
+           zope.publisher.interfaces.browser.IBrowserRequest"
       name="AnalysisRequest"
       factory=".reportview.SingleReportView"
       provides="senaite.impress.interfaces.IReportView"
@@ -14,7 +15,8 @@
 
   <!-- View for Multi Reports -->
   <adapter
-      for="*"
+      for="zope.interface.Interface
+           zope.publisher.interfaces.browser.IBrowserRequest"
       name="AnalysisRequest"
       factory=".reportview.MultiReportView"
       provides="senaite.impress.interfaces.IMultiReportView"

--- a/src/senaite/impress/analysisrequest/reportview.py
+++ b/src/senaite/impress/analysisrequest/reportview.py
@@ -233,10 +233,10 @@ class SingleReportView(ReportView):
     """View for Single Reports
     """
 
-    def __init__(self, model):
+    def __init__(self, model, request):
         logger.info("SingleReportView::__init__:model={}"
                     .format(model))
-        super(SingleReportView, self).__init__(model=model)
+        super(SingleReportView, self).__init__(model, request)
         self.model = model
         self.context = model.instance
         self.request = api.get_request()
@@ -257,12 +257,12 @@ class MultiReportView(ReportView):
     """View for Multi Reports
     """
 
-    def __init__(self, collection):
+    def __init__(self, collection, request):
         logger.info("MultiReportView::__init__:collection={}"
                     .format(collection))
-        super(MultiReportView, self).__init__(collection=collection)
+        super(MultiReportView, self).__init__(collection, request)
         self.collection = collection
-        self.request = api.get_request()
+        self.request = request
 
         # needed for template rendering
         self.context = api.get_portal()

--- a/src/senaite/impress/analysisrequest/reportview.py
+++ b/src/senaite/impress/analysisrequest/reportview.py
@@ -238,8 +238,7 @@ class SingleReportView(ReportView):
                     .format(model))
         super(SingleReportView, self).__init__(model, request)
         self.model = model
-        self.context = model.instance
-        self.request = api.get_request()
+        self.request = request
 
     def render(self, template):
         context = self.get_template_context(self.model)
@@ -263,9 +262,6 @@ class MultiReportView(ReportView):
         super(MultiReportView, self).__init__(collection, request)
         self.collection = collection
         self.request = request
-
-        # needed for template rendering
-        self.context = api.get_portal()
 
     def render(self, template):
         """Wrap the template and render

--- a/src/senaite/impress/publishview.py
+++ b/src/senaite/impress/publishview.py
@@ -5,9 +5,9 @@
 # Copyright 2018 by it's authors.
 
 import os
-from string import Template
 from collections import Iterable
 from collections import OrderedDict
+from string import Template
 
 from Products.Five import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
@@ -22,6 +22,7 @@ from senaite.impress.interfaces import IReportView
 from senaite.impress.interfaces import ITemplateFinder
 from zope.component import ComponentLookupError
 from zope.component import getAdapter
+from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.interface import implements
 
@@ -162,14 +163,19 @@ class PublishView(BrowserView):
         """Render a SuperModel to HTML
         """
         _type = self.get_report_type()
-        view = getAdapter(model, IReportView, name=_type)
+        # Query the controller view as a multi-adapter to allow 3rd party
+        # overriding with a browser layer
+        view = getMultiAdapter((model, self.request), IReportView, name=_type)
         return view.render(self.read_template(template, view, **kw))
 
     def render_multi_report(self, collection, template, **kw):
         """Render multiple SuperModels to HTML
         """
         _type = self.get_report_type()
-        view = getAdapter(collection, IMultiReportView, name=_type)
+        # Query the controller view as a multi-adapter to allow 3rd party
+        # overriding with a browser layer
+        view = getMultiAdapter(
+            (collection, self.request), IMultiReportView, name=_type)
         return view.render(self.read_template(template, view, **kw))
 
     def get_print_css(self, paperformat="A4", orientation="portrait"):

--- a/src/senaite/impress/reportview.py
+++ b/src/senaite/impress/reportview.py
@@ -4,6 +4,7 @@
 #
 # Copyright 2018 by it's authors.
 
+from senaite import api
 from senaite.impress.interfaces import IReportView
 from zope.interface import implements
 
@@ -15,9 +16,9 @@ class ReportView(object):
     """
     implements(IReportView)
 
-    def __init__(self, context, request):
-        self.context = context
-        self.request = request
+    def __init__(self, *args, **kwargs):
+        # needed for template rendering
+        self.context = api.get_portal()
 
     def render(self, template):
         raise NotImplemented("Must be implemented by subclass")

--- a/src/senaite/impress/reportview.py
+++ b/src/senaite/impress/reportview.py
@@ -15,9 +15,9 @@ class ReportView(object):
     """
     implements(IReportView)
 
-    def __init__(self, model=None, collection=None):
-        self.model = model
-        self.collection = collection
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
 
     def render(self, template):
         raise NotImplemented("Must be implemented by subclass")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This allows 3rd party Add-ons to override the adapter with a specific browser
layer interface like this:

    <adapter
        for="zope.interface.Interface
            my.addon.interfaces.IMyAddonLayerInterface"
        name="AnalysisRequest"
        factory=".reportview.SingleReportView"
        provides="senaite.impress.interfaces.IReportView"
        permission="zope2.View"/>

## Current behavior before PR

Add-on specific report controller views could not be registered

## Desired behavior after PR is merged

Add-on specific report controller views can be registered

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
