### PR TITLE
Fixed i18n domain for time localization

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.0.3 (unreleased)
 ------------------
 
+- #28: Fixed i18n domain for time localization
 - #27: Refactored Report Adapters to Multi Adapters
 - #25: Added controlpanel descriptions
 - #24: Control individual report generation for multi-report PDFs

--- a/src/senaite/impress/analysisrequest/reportview.py
+++ b/src/senaite/impress/analysisrequest/reportview.py
@@ -104,7 +104,7 @@ class ReportView(Base):
             "time_only": False,
             "context": api.get_portal(),
             "request": api.get_request(),
-            "domain": "bika",
+            "domain": "senaite.core",
         }
         options.update(kw)
         return ulocalized_time(date, **options)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the domain from `bika` to `senaite.core`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
