### PR TITLE
Added report developer mode

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.0.3 (unreleased)
 ------------------
 
+- #29: Added report developer mode
 - #28: Fixed i18n domain for time localization
 - #27: Refactored Report Adapters to Multi Adapters
 - #25: Added controlpanel descriptions

--- a/src/senaite/impress/ajax.py
+++ b/src/senaite/impress/ajax.py
@@ -279,6 +279,9 @@ class AjaxPublishView(PublishView):
         # N.B. It might also contain multiple reports!
         html = data.get("html")
 
+        if self.get_developer_mode():
+            return html
+
         # Metadata
         paperformat = data.get("format")
         orientation = data.get("orientation", "portrait")

--- a/src/senaite/impress/controlpanel.py
+++ b/src/senaite/impress/controlpanel.py
@@ -58,6 +58,13 @@ class IImpressControlPanel(Interface):
         required=True,
     )
 
+    developer_mode = schema.Bool(
+        title=_(u"Developer Mode"),
+        description=_("Returns the raw HTML in the report preview."),
+        default=False,
+        required=False,
+    )
+
 
 class ImpressControlPanelForm(RegistryEditForm):
     schema = IImpressControlPanel

--- a/src/senaite/impress/publishview.py
+++ b/src/senaite/impress/publishview.py
@@ -265,6 +265,13 @@ class PublishView(BrowserView):
             "senaite.impress.store_multireports_individually")
         return store_individually
 
+    def get_developer_mode(self):
+        """Returns the configured setting from the registry
+        """
+        mode = api.get_registry_record(
+            "senaite.impress.developer_mode", False)
+        return mode
+
     def get_report_template(self, template=None):
         """Returns the path of report template
         """


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds a control-panel option to enable/disable the developer mode.

With the developer mode turned on, the report will be returned as plain HTML.
This allows the report designer to quickly render the report and being able to introspect the HTML.

## Current behavior before PR

No developer mode available

## Desired behavior after PR is merged

Developer mode available

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
