### PR TITLE
Keep order of grouped items

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.0.3 (unreleased)
 ------------------
 
+- #30: Keep order of grouped items
 - #29: Added report developer mode
 - #28: Fixed i18n domain for time localization
 - #27: Refactored Report Adapters to Multi Adapters

--- a/src/senaite/impress/analysisrequest/reportview.py
+++ b/src/senaite/impress/analysisrequest/reportview.py
@@ -7,7 +7,6 @@
 from collections import Iterable
 from collections import OrderedDict
 from collections import Sequence
-from collections import defaultdict
 from itertools import chain
 from operator import itemgetter
 from string import Template
@@ -197,12 +196,15 @@ class ReportView(Base):
         """
         if not isinstance(items, Iterable):
             raise TypeError("Items must be iterable")
-        results = defaultdict(list)
+        results = OrderedDict()
         for item in items:
             group_key = item[key]
             if callable(group_key):
                 group_key = group_key()
-            results[group_key].append(item)
+            if group_key not in results:
+                results[group_key] = [item]
+            else:
+                results[group_key].append(item)
         return results
 
     def group_into_chunks(self, items, chunk_size=1):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR ensures the order of grouped items

## Current behavior before PR

grouped items order not kept

## Desired behavior after PR is merged

grouped items keep initial order

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
