### PR TITLE
Fix sort order of uniquified items

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.0.3 (unreleased)
 ------------------
 
+- #31: Fix sort order of uniquified items
 - #30: Keep order of grouped items
 - #29: Added report developer mode
 - #28: Fixed i18n domain for time localization

--- a/src/senaite/impress/analysisrequest/reportview.py
+++ b/src/senaite/impress/analysisrequest/reportview.py
@@ -223,6 +223,16 @@ class ReportView(Base):
             key = itemgetter(key)
         return sorted(items, key=key, reverse=reverse)
 
+    def uniquify_items(self, items):
+        """Uniquify the items with sort order
+        """
+        unique = []
+        for item in items:
+            if item in unique:
+                continue
+            unique.append(item)
+        return unique
+
     def to_list(self, model_or_collection):
         if ISuperModel.providedBy(model_or_collection):
             return [model_or_collection]

--- a/src/senaite/impress/templates/reports/MultiDefault.pt
+++ b/src/senaite/impress/templates/reports/MultiDefault.pt
@@ -503,7 +503,7 @@
 
   <!--  SIGNATURES -->
   <tal:render condition="python:True">
-    <tal:responsibles define="managers python:set(reduce(lambda a1, a2: a1+a2, map(lambda m: m.managers, collection)))">
+    <tal:responsibles define="managers python:view.uniquify_items(reduce(lambda a1, a2: a1+a2, map(lambda m: m.managers, collection)))">
       <div class="row section-signatures">
         <div class="col-sm-12">
           <h1 i18n:translate="">Responsibles</h1>

--- a/src/senaite/impress/templates/reports/MultiDefaultByColumn.pt
+++ b/src/senaite/impress/templates/reports/MultiDefaultByColumn.pt
@@ -117,7 +117,7 @@
                   <td class="label" i18n:translate="">Sample Type</td>
                   <td class="field">
                     <tal:sampletype define="sampletypes python:map(lambda m: m.SampleTypeTitle, samples)"
-                                    repeat="sampletype python:set(sampletypes)">
+                                    repeat="sampletype python:view.uniquify_items(sampletypes)">
                       <div tal:content="sampletype"/>
                     </tal:sampletype>
                   </td>
@@ -127,7 +127,7 @@
                   <td class="label" i18n:translate="">Sample Point</td>
                   <td class="field">
                     <tal:samplepoint define="samplepoints python:map(lambda m: m.SamplePointTitle, samples)"
-                                     repeat="samplepoint python:set(samplepoints)">
+                                     repeat="samplepoint python:view.uniquify_items(samplepoints)">
                       <div tal:content="samplepoint"/>
                     </tal:samplepoint>
                   </td>
@@ -264,8 +264,9 @@
                   </td>
                 </tr>
                 <tr tal:define="analyses python:view.get_analyses_by(collection, poc=poc, category=category);
-                                analyses_by_title python:set(map(lambda a: a.Title(), analyses))"
-                    tal:repeat="analysis_title python:analyses_by_title">
+                                analyses_by_title python:map(lambda a: a.Title(), analyses);
+                                analyses_titles python:view.uniquify_items(analyses_by_title)"
+                    tal:repeat="analysis_title python:analyses_titles">
                   <td class="text-secondary">
                     <span tal:content="analysis_title"/>
                   </td>
@@ -417,7 +418,7 @@
 
   <!--  SIGNATURES -->
   <tal:render condition="python:True">
-    <tal:responsibles define="managers python:set(reduce(lambda a1, a2: a1+a2, map(lambda m: m.managers, collection)))">
+    <tal:responsibles define="managers python:view.uniquify_items(reduce(lambda a1, a2: a1+a2, map(lambda m: m.managers, collection)))">
       <div class="row section-signatures">
         <div class="col-sm-12">
           <h1 i18n:translate="">Responsibles</h1>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the sort order of uniquified items, e.g. the Analyses Titles in the Multi-Default-By-Column Report.

## Current behavior before PR

`set` is used to uniquify the items, which does not maintain the sort order of the list

## Desired behavior after PR is merged

`view.uniquify_items` method is used, which maintains the sort order of the imtes

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
