### PR TITLE
Include uncooked JS resources from portal_javascripts

### DIFF
--- a/src/senaite/impress/javascripts.py
+++ b/src/senaite/impress/javascripts.py
@@ -19,7 +19,7 @@ INCLUDE = [
 
 
 class JavaScriptsView(BrowserView):
-    """Helper View to inject JS from portal_javascripts
+    """Helper View to inject uncooked JS from portal_javascripts
 
     Most of it copied from Products.ResourceRegistries
     https://github.com/plone/Products.ResourceRegistries/blob/master/Products/ResourceRegistries/browser/scripts.pt
@@ -34,36 +34,26 @@ class JavaScriptsView(BrowserView):
     def scripts(self):
         registry = self.registry()
         registry_url = registry.absolute_url()
-        context = aq_inner(self.context)
-
-        scripts = registry.getEvaluatedResources(context)
         skinname = url_quote(self.skinname())
+        # get the uncooked resources
+        scripts = registry.getResources()
         result = []
 
         for script in scripts:
-
+            # only consider enabled JS resources
+            if not script.getEnabled():
+                continue
             # Only include JS where the regular expression matches
             script_id = script.getId()
             if not any(map(lambda rx: re.findall(rx, script_id), INCLUDE)):
                 continue
 
-            inline = bool(script.getInline())
-            if inline:
-                content = registry.getInlineResource(script.getId(), context)
-                data = {
-                    "inline": inline,
-                    "conditionalcomment": script.getConditionalcomment(),
-                    "content": content,
-                }
+            if script.isExternalResource():
+                src = "%s" % (script.getId(),)
             else:
-                if script.isExternalResource():
-                    src = "%s" % (script.getId(),)
-                else:
-                    src = "%s/%s/%s" % (registry_url, skinname, script.getId())
-                data = {
-                    "inline": inline,
-                    "conditionalcomment": script.getConditionalcomment(),
-                    "src": src,
-                }
+                src = "%s/%s/%s" % (registry_url, skinname, script.getId())
+            data = {
+                "src": src,
+            }
             result.append(data)
         return result

--- a/src/senaite/impress/templates/publish.pt
+++ b/src/senaite/impress/templates/publish.pt
@@ -31,18 +31,7 @@
     <!-- PORTAL JS -->
     <tal:portal_javascripts define="view context/@@javascripts_view"
                             repeat="script view/scripts">
-      <tal:block define="inline script/inline;
-                         condcomment script/conditionalcomment">
-        <tal:jquery condition="not:inline">
-          <script type="text/javascript" tal:attributes="src script/src"></script>
-        </tal:jquery>
-        <tal:inline condition="inline">
-          <script type="text/javascript" tal:content="structure script/content"></script>
-        </tal:inline>
-        <tal:wcondcomment tal:condition="condcomment">
-          <tal:closecc tal:replace="structure string:&lt;![endif]--&gt;" />
-        </tal:wcondcomment>
-      </tal:block>
+      <script type="text/javascript" tal:attributes="src script/src"></script>
     </tal:portal_javascripts>
     <!-- /PORTAL JS -->
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR ensures that only uncooked JS resources are used in the publish view.

## Current behavior before PR

Cooked (merged) JS resources were used in the publish view

## Desired behavior after PR is merged

Unmerged JS libraries are used in the publish view

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
