### PR TITLE
Added some auxiliary code

### DIFF
--- a/src/senaite/impress/analysisrequest/reportview.py
+++ b/src/senaite/impress/analysisrequest/reportview.py
@@ -260,9 +260,16 @@ class ReportView(Base):
     def get_transition_date(self, obj, transition=None):
         """Returns the date of the given Transition
         """
+        if self.is_model(obj):
+            obj = obj.instance
         if transition is None:
             return None
         return getTransitionDate(obj, transition, return_as_datetime=True)
+
+    def is_model(self, obj):
+        """Check if the given object is a SuperModel
+        """
+        return ISuperModel.providedBy(obj)
 
 
 class SingleReportView(ReportView):

--- a/src/senaite/impress/publishview.py
+++ b/src/senaite/impress/publishview.py
@@ -216,6 +216,7 @@ class PublishView(BrowserView):
             "page_height": page_height,
             "content_width": content_width,
             "content_height": content_height,
+            "orientation": orientation,
         })
         return dimensions
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Propagate orientation to page template

Support SuperModel in get_transition_date method

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
