### PR TITLE
Combine Attachments coming from Request and Analysis together for unified grouping/sorting

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.0.3 (unreleased)
 ------------------
 
+- #42: Combine Attachments coming from Request and Analysis together for unified grouping/sorting
 - #41: Default reports update
 - #40: Customizable report options
 - #37: Added hyphenize and get_transition_date helper methods

--- a/src/senaite/impress/analysisrequest/model.py
+++ b/src/senaite/impress/analysisrequest/model.py
@@ -4,6 +4,8 @@
 #
 # Copyright 2018 by it's authors.
 
+import itertools
+
 from bika.lims.utils import format_supsub
 from bika.lims.utils import formatDecimalMark
 from bika.lims.utils import to_utf8
@@ -154,6 +156,15 @@ class SuperModel(BaseModel):
             out.append({"title": title, "richtext": richtext})
 
         return out
+
+    def get_sorted_attachments(self, option="r"):
+        """Return the sorted AR/AN Attachments with the given Report Option set
+        """
+        ar_attachments = self.Attachment
+        an_attachments = [a for a in itertools.chain(*map(
+            lambda an: an.Attachment, self.Analyses))]
+        attachments = ar_attachments + an_attachments
+        return self.sort_attachments(attachments)
 
     def get_sorted_ar_attachments(self, option="r"):
         """Return the sorted AR Attchments with the given Report Option set

--- a/src/senaite/impress/analysisrequest/reportview.py
+++ b/src/senaite/impress/analysisrequest/reportview.py
@@ -216,11 +216,13 @@ class ReportView(Base):
         return results
 
     def group_into_chunks(self, items, chunk_size=1):
-        """Group items into chunks of the given sizesize
+        """Group items into chunks of the given size
         """
         if chunk_size > len(items):
             chunk_size = len(items)
-        return zip(*[iter(items)] * chunk_size)
+
+        for i in range(0, len(items), chunk_size):
+            yield items[i:i + chunk_size]
 
     def sort_items_by(self, key, items, reverse=False):
         """Sort the items (mappings with dict interface) by the given key

--- a/src/senaite/impress/templates/reports/Default.pt
+++ b/src/senaite/impress/templates/reports/Default.pt
@@ -513,60 +513,38 @@
   </tal:render>
 
   <!-- ATTACHMENTS -->
-  <tal:render condition="python:True"
-              define="ar_attachments python:model.get_sorted_ar_attachments('r');
-                      an_attachments python:model.get_sorted_an_attachments('r');">
-
-    <h1 i18n:translate=""
-        tal:condition="python:ar_attachments or an_attachments">
-      Attachments
-    </h1>
-
-    <!-- AR ATTACHMENTS -->
-    <div class="row section-attachments no-gutters" tal:condition="ar_attachments">
-      <div class="small">
-        <table class="table w-100">
-          <colgroup>
-            <col tal:attributes="style python:'width:{}%'.format(100/attachments_per_row)">
+  <tal:render condition="python:True">
+    <div class="row section-attachments no-gutters">
+      <tal:attachment tal:define="attachments python:model.get_sorted_attachments('r');">
+        <h2 i18n:translate=""
+            tal:condition="attachments">
+          Attachments for <span tal:replace="model/getId"/>
+        </h2>
+        <table class="table w-100" tal:condition="attachments">
+          <colgroup tal:condition="python:len(attachments) > 1">
+            <col tal:repeat="col python:range(attachments_per_row)"
+                  tal:attributes="style python:'width:{}%'.format(100/attachments_per_row)">
           </colgroup>
-          <tr tal:repeat="chunk python:view.group_into_chunks(ar_attachments, attachments_per_row)">
+          <tr tal:repeat="chunk python:view.group_into_chunks(attachments, attachments_per_row)">
             <td class="align-bottom"
                 style="border:none;padding-left:0;"
                 tal:repeat="attachment chunk">
-              <img class="img-fluid"
-                   tal:attributes="src string:${attachment/absolute_url}/AttachmentFile;
-                                   style python:len(ar_attachments)==1 and 'max-width:%.2fmm' % (float(content_width))"/>
-              <div class="text-secondary">
-                <span tal:content="attachment/AttachmentKeys"/>
-              </div>
+              <figure class="figure">
+                <img class="figure-img img-fluid"
+                      tal:attributes="src string:${attachment/absolute_url}/AttachmentFile;
+                            style python:len(attachments)==1 and 'max-width:%.2fmm' % (float(content_width))"/>
+                <figcaption class="figure-caption pt-2">
+                  <div i18n:translate="">
+                    Attachment for
+                    <span tal:replace="attachment/getTextTitle|model/getId"/>
+                  </div>
+                  <span tal:content="attachment/AttachmentKeys"/>
+                </figcaption>
+              </figure>
             </td>
           </tr>
         </table>
-      </div>
-    </div>
-
-    <!-- AN ATTACHMENTS -->
-    <div class="row section-attachments no-gutters" tal:condition="an_attachments">
-      <div class="small">
-        <table class="table w-100">
-          <colgroup>
-            <col tal:attributes="style python:'width:{}%'.format(100/attachments_per_row)">
-          </colgroup>
-          <tr tal:repeat="chunk python:view.group_into_chunks(an_attachments, attachments_per_row)">
-            <td class="align-bottom"
-                style="border:none;padding-left:0;"
-                tal:repeat="attachment chunk">
-              <img class="img-fluid"
-                   tal:attributes="src python:attachment[1].absolute_url() + '/AttachmentFile';
-                                   style python:len(an_attachments)==1 and 'max-width:%.2fmm' % (float(content_width))"/>
-              <div class="text-secondary">
-                <span tal:content="python:attachment[1].getAnalysis().title"/>:
-                <span tal:content="python:attachment[1].AttachmentKeys"/>
-              </div>
-            </td>
-          </tr>
-        </table>
-      </div>
+      </tal:attachment>
     </div>
   </tal:render>
 

--- a/src/senaite/impress/templates/reports/MultiDefault.pt
+++ b/src/senaite/impress/templates/reports/MultiDefault.pt
@@ -537,64 +537,40 @@
   </tal:render>
 
   <!-- ATTACHMENTS -->
-  <tal:render condition="python:True"
-              define="attachments_per_row python:2">
+  <tal:render condition="python:True">
     <tal:model repeat="model collection">
-      <tal:attachment tal:define="ar_attachments python:model.get_sorted_ar_attachments('r');
-                                  an_attachments python:model.get_sorted_an_attachments('r')">
-
-        <h1 i18n:translate=""
-            tal:condition="python:ar_attachments or an_attachments">
-          Attachments
-        </h1>
-
-        <!-- AR ATTACHMENTS -->
-        <div class="row section-attachments no-gutters" tal:condition="ar_attachments">
-          <div class="small">
-            <table class="table w-100">
-              <colgroup>
-                <col tal:attributes="style python:'width:{}%'.format(100/attachments_per_row)">
-              </colgroup>
-              <tr tal:repeat="chunk python:view.group_into_chunks(ar_attachments, attachments_per_row)">
-                <td class="align-bottom"
-                    style="border:none;padding-left:0;"
-                    tal:repeat="attachment chunk">
-                  <img class="img-fluid"
+      <div class="row section-attachments no-gutters">
+        <tal:attachment tal:define="attachments python:model.get_sorted_attachments('r');">
+          <h2 i18n:translate=""
+              tal:condition="attachments">
+            Attachments for <span tal:replace="model/getId"/>
+          </h2>
+          <table class="table w-100" tal:condition="attachments">
+            <colgroup tal:condition="python:len(attachments) > 1">
+              <col tal:repeat="col python:range(attachments_per_row)"
+                   tal:attributes="style python:'width:{}%'.format(100/attachments_per_row)">
+            </colgroup>
+            <tr tal:repeat="chunk python:view.group_into_chunks(attachments, attachments_per_row)">
+              <td class="align-bottom"
+                  style="border:none;padding-left:0;"
+                  tal:repeat="attachment chunk">
+                <figure class="figure">
+                  <img class="figure-img img-fluid"
                        tal:attributes="src string:${attachment/absolute_url}/AttachmentFile;
-                              style python:len(ar_attachments)==1 and 'max-width:%.2fmm' % (float(content_width))"/>
-                  <div class="text-secondary">
+                              style python:len(attachments)==1 and 'max-width:%.2fmm' % (float(content_width))"/>
+                  <figcaption class="figure-caption pt-2">
+                    <div i18n:translate="">
+                      Attachment for
+                      <span tal:replace="attachment/getTextTitle|model/getId"/>
+                    </div>
                     <span tal:content="attachment/AttachmentKeys"/>
-                  </div>
-                </td>
-              </tr>
-            </table>
-          </div>
-        </div>
-
-        <!-- AN ATTACHMENTS -->
-        <div class="row section-attachments no-gutters" tal:condition="an_attachments">
-          <div class="small">
-            <table class="table w-100">
-              <colgroup>
-                <col tal:attributes="style python:'width:{}%'.format(100/attachments_per_row)">
-              </colgroup>
-              <tr tal:repeat="chunk python:view.group_into_chunks(an_attachments, attachments_per_row)">
-                <td class="align-bottom"
-                    style="border:none;padding-left:0;"
-                    tal:repeat="attachment chunk">
-                  <img class="img-fluid"
-                       tal:attributes="src python:attachment[1].absolute_url() + '/AttachmentFile';
-                              style python:len(an_attachments)==1 and 'max-width:%.2fmm' % (float(content_width))"/>
-                  <div class="text-secondary">
-                    <span tal:content="python:attachment[1].getAnalysis().title"/>:
-                    <span tal:content="python:attachment[1].AttachmentKeys"/>
-                  </div>
-                </td>
-              </tr>
-            </table>
-          </div>
-        </div>
-      </tal:attachment>
+                  </figcaption>
+                </figure>
+              </td>
+            </tr>
+          </table>
+        </tal:attachment>
+      </div>
     </tal:model>
   </tal:render>
 

--- a/src/senaite/impress/templates/reports/MultiDefaultByColumn.pt
+++ b/src/senaite/impress/templates/reports/MultiDefaultByColumn.pt
@@ -450,64 +450,41 @@
   </tal:render>
 
   <!-- ATTACHMENTS -->
-  <tal:render condition="python:True"
-              define="attachments_per_row python:2">
-    <tal:model repeat="model collection">
-      <tal:attachment tal:define="ar_attachments python:model.get_sorted_ar_attachments('r');
-                                  an_attachments python:model.get_sorted_an_attachments('r')"
-                      tal:condition="python: ar_attachments or an_attachments">
-
-        <h2 i18n:translate="">
-          Attachments for <span tal:replace="model/getId"/>
-        </h2>
-        <!-- AR ATTACHMENTS -->
-        <div class="row section-attachments no-gutters" tal:condition="ar_attachments">
-          <div class="small">
-            <table class="table w-100">
-              <colgroup>
-                <col tal:attributes="style python:'width:{}%'.format(100/attachments_per_row)">
-              </colgroup>
-              <tr tal:repeat="chunk python:view.group_into_chunks(ar_attachments, attachments_per_row)">
-                <td class="align-bottom"
-                    style="border:none;padding-left:0;"
-                    tal:repeat="attachment chunk">
-                  <img class="img-fluid"
+  <tal:render condition="python:True">
+    <div class="row section-attachments no-gutters">
+      <tal:model repeat="model collection">
+        <tal:attachment tal:define="attachments python:model.get_sorted_attachments('r');">
+          <h2 i18n:translate=""
+              tal:condition="attachments">
+            Attachments for <span tal:replace="model/getId"/>
+          </h2>
+          <table class="table w-100" tal:condition="attachments">
+            <colgroup tal:condition="python:len(attachments) > 1">
+              <col tal:repeat="col python:range(attachments_per_row)"
+                   tal:attributes="style python:'width:{}%'.format(100/attachments_per_row)">
+            </colgroup>
+            <tr tal:repeat="chunk python:view.group_into_chunks(attachments, attachments_per_row)">
+              <td class="align-bottom"
+                  style="border:none;padding-left:0;"
+                  tal:repeat="attachment chunk">
+                <figure class="figure">
+                  <img class="figure-img img-fluid"
                        tal:attributes="src string:${attachment/absolute_url}/AttachmentFile;
-                              style python:len(ar_attachments)==1 and 'max-width:%.2fmm' % (float(content_width))"/>
-                  <div class="text-secondary">
+                              style python:len(attachments)==1 and 'max-width:%.2fmm' % (float(content_width))"/>
+                  <figcaption class="figure-caption pt-2">
+                    <div i18n:translate="">
+                      Attachment for
+                      <span tal:replace="attachment/getTextTitle|model/getId"/>
+                    </div>
                     <span tal:content="attachment/AttachmentKeys"/>
-                  </div>
-                </td>
-              </tr>
-            </table>
-          </div>
-        </div>
-
-        <!-- AN ATTACHMENTS -->
-        <div class="row section-attachments no-gutters" tal:condition="an_attachments">
-          <div class="small">
-            <table class="table w-100">
-              <colgroup>
-                <col tal:attributes="style python:'width:{}%'.format(100/attachments_per_row)">
-              </colgroup>
-              <tr tal:repeat="chunk python:view.group_into_chunks(an_attachments, attachments_per_row)">
-                <td class="align-bottom"
-                    style="border:none;padding-left:0;"
-                    tal:repeat="attachment chunk">
-                  <img class="img-fluid"
-                       tal:attributes="src python:attachment[1].absolute_url() + '/AttachmentFile';
-                              style python:len(an_attachments)==1 and 'max-width:%.2fmm' % (float(content_width))"/>
-                  <div class="text-secondary">
-                    <span tal:content="python:attachment[1].getAnalysis().title"/>:
-                    <span tal:content="python:attachment[1].AttachmentKeys"/>
-                  </div>
-                </td>
-              </tr>
-            </table>
-          </div>
-        </div>
-      </tal:attachment>
-    </tal:model>
+                  </figcaption>
+                </figure>
+              </td>
+            </tr>
+          </table>
+        </tal:attachment>
+      </tal:model>
+    </div>
   </tal:render>
 
   <!--  SIGNATURES -->


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR combines the AR/AN Attachments per AR in the reports, so that the sorting applies correctly.

## Current behavior before PR

AR Attachments were rendered separately from AN Attachments

## Desired behavior after PR is merged

AR and AN Attachments are rendered combined in reports

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
