### PR TITLE
Changed field ChildAnalysisRequest -> Retest

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.1.0 (unreleased)
 ------------------
 
+- #44: Changed field ChildAnalysisRequest -> Retest
 - #42: Combine Attachments coming from Request and Analysis together for unified grouping/sorting
 - #41: Default reports update
 - #40: Customizable report options

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,4 +1,4 @@
-1.0.3 (unreleased)
+1.1.0 (unreleased)
 ------------------
 
 - #42: Combine Attachments coming from Request and Analysis together for unified grouping/sorting

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-version = "1.0.3"
+version = "1.1.0"
 
 with open("docs/About.rst", "r") as fh:
     long_description = fh.read()
@@ -41,7 +41,7 @@ setup(
     install_requires=[
         "setuptools",
         "senaite.api>=1.2.0",
-        "senaite.core>=1.2.7",
+        "senaite.core>=1.2.9",
         "senaite.core.supermodel>=1.0.0",
         "beautifulsoup4",
         "archetypes.schemaextender",

--- a/src/senaite/impress/templates/reports/Default.pt
+++ b/src/senaite/impress/templates/reports/Default.pt
@@ -253,7 +253,7 @@
       <div class="w-100 mb-2">
         <div class="alert alert-danger" tal:condition="model/is_invalid">
           <div i18n:translate="">This Analysis Request has been invalidated due to erroneously published results</div>
-          <tal:invalidreport tal:define="child model/ChildAnalysisRequest"
+          <tal:invalidreport tal:define="child model/Retest"
                              tal:condition="child">
             <span i18n:translate="">This Analysis request has been replaced by</span>
             <a tal:attributes="href child/absolute_url"

--- a/src/senaite/impress/templates/reports/MultiDefault.pt
+++ b/src/senaite/impress/templates/reports/MultiDefault.pt
@@ -257,7 +257,7 @@
           <div class="alert alert-danger" tal:condition="model/is_invalid">
             <h2 class="alert-heading"><span tal:replace="model/getId"/></h2>
             <div i18n:translate="">This Analysis Request has been invalidated due to erroneously published results</div>
-            <tal:invalidreport tal:define="child model/ChildAnalysisRequest"
+            <tal:invalidreport tal:define="child model/Retest"
                                tal:condition="child">
               <span i18n:translate="">This Analysis request has been replaced by</span>
               <a tal:attributes="href child/absolute_url"

--- a/src/senaite/impress/templates/reports/MultiDefaultByColumn.pt
+++ b/src/senaite/impress/templates/reports/MultiDefaultByColumn.pt
@@ -307,7 +307,7 @@
           <div class="alert alert-danger" tal:condition="model/is_invalid">
             <h2 class="alert-heading"><span tal:replace="model/getId"/></h2>
             <div i18n:translate="">This Analysis Request has been invalidated due to erroneously published results</div>
-            <tal:invalidreport tal:define="child model/ChildAnalysisRequest"
+            <tal:invalidreport tal:define="child model/Retest"
                                tal:condition="child">
               <span i18n:translate="">This Analysis request has been replaced by</span>
               <a tal:attributes="href child/absolute_url"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR integrates the latest changes from https://github.com/senaite/senaite.core/pull/1027 into impress and pins `senaite.core` to `>=1.2.9`.

## Current behavior before PR

`ChildAnalysisRequest` field was used

## Desired behavior after PR is merged

`Retest` field is used

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
