### PR TITLE
Update Template Markup/Style

### DIFF
--- a/src/senaite/impress/templates/reports/Default.pt
+++ b/src/senaite/impress/templates/reports/Default.pt
@@ -46,7 +46,7 @@
 
   <tal:css define="footer_text python:view.get_footer_text();">
     <style type="text/css">
-     .report * { font: 9pt Arial, Verdana, sans-serif; }
+     .report * { font: 9pt; }
      .report h1 { font-size: 140%; }
      .report h2 { font-size: 120%; }
      .report h3 { font-size: 110%; }
@@ -92,6 +92,10 @@
        max-width: <tal:t replace="python:'{:.2f}mm'.format(cw / attachments_per_row)"/>;
        max-height: <tal:t replace="python:'{:.2f}mm'.format(ch * 0.75)"/>;
      }
+     .report .section-resultsinterpretation img {
+       max-width: <tal:t replace="python:'{:.2f}mm'.format(cw)"/>;
+       max-height: <tal:t replace="python:'{:.2f}mm'.format(ch * 0.75)"/>;
+     }
      </tal:block>
      @page {
        <tal:footer condition="footer_text">
@@ -122,7 +126,7 @@
   <tal:render condition="python:True">
     <div class="row section-header no-gutters">
       <!-- Header Table -->
-      <div class="col-sm-12 mb-2">
+      <div class="w-100 mb-2">
         <table class="w-100 mb-0 noborder">
           <colgroup>
             <col style="width:50%"/>
@@ -148,7 +152,7 @@
   <!-- INFO -->
   <tal:render condition="python:True">
   <div class="row section-info no-gutters">
-    <div class="col-sm-12">
+    <div class="w-100">
       <!-- Client Info -->
       <table class="table table-sm table-condensed w-100">
         <colgroup>
@@ -530,14 +534,19 @@
                 tal:repeat="attachment chunk">
               <figure class="figure">
                 <img class="figure-img img-fluid"
-                      tal:attributes="src string:${attachment/absolute_url}/AttachmentFile;
-                            style python:len(attachments)==1 and 'max-width:%.2fmm' % (float(content_width))"/>
+                     tal:attributes="src string:${attachment/absolute_url}/AttachmentFile;"/>
                 <figcaption class="figure-caption pt-2">
-                  <div i18n:translate="">
-                    Attachment for
-                    <span tal:replace="attachment/getTextTitle|model/getId"/>
+                  <div class="att_for">
+                    <span i18n:translate="">Attachment for</span>
+                    <span tal:content="attachment/getTextTitle|model/getId"/>
                   </div>
-                  <span tal:content="attachment/AttachmentKeys"/>
+                  <div class="att_keys">
+                    <span tal:content="attachment/AttachmentKeys"/>
+                  </div>
+                  <div class="att_filename">
+                    <span i18n:translate="">Filename:</span>
+                    <span tal:content="attachment/AttachmentFile/filename"/>
+                  </div>
                 </figcaption>
               </figure>
             </td>

--- a/src/senaite/impress/templates/reports/MultiDefault.pt
+++ b/src/senaite/impress/templates/reports/MultiDefault.pt
@@ -1,6 +1,7 @@
 <tal:report
   i18n:domain="senaite.impress"
   define="collection view/collection;
+          laboratory view/laboratory;
           accredited_symbol string:★;
           outofrange_symbol string:⚠;
           report_options python:options.get('report_options', {});

--- a/src/senaite/impress/templates/reports/MultiDefault.pt
+++ b/src/senaite/impress/templates/reports/MultiDefault.pt
@@ -44,7 +44,7 @@
 
   <tal:css define="footer_text python:view.get_footer_text();">
     <style type="text/css">
-     .report * { font: 9pt Arial, Verdana, sans-serif; }
+     .report * { font: 9pt; }
      .report h1 { font-size: 140%; }
      .report h2 { font-size: 120%; }
      .report h3 { font-size: 110%; }
@@ -90,6 +90,10 @@
        max-width: <tal:t replace="python:'{:.2f}mm'.format(cw / attachments_per_row)"/>;
        max-height: <tal:t replace="python:'{:.2f}mm'.format(ch * 0.75)"/>;
      }
+     .report .section-resultsinterpretation img {
+       max-width: <tal:t replace="python:'{:.2f}mm'.format(cw)"/>;
+       max-height: <tal:t replace="python:'{:.2f}mm'.format(ch * 0.75)"/>;
+     }
      </tal:block>
      @page {
        <tal:footer condition="footer_text">
@@ -120,7 +124,7 @@
   <tal:render condition="python:True">
     <div class="row section-header no-gutters">
       <!-- Header Table -->
-      <div class="col-sm-12 mb-2">
+      <div class="w-100 mb-2">
         <table class="w-100 mb-0 noborder">
           <colgroup>
             <col style="width:50%"/>
@@ -151,7 +155,7 @@
                       laboratory python:view.laboratory;">
 
     <div class="row section-info no-gutters">
-      <div class="col-sm-12">
+      <div class="w-100">
         <!-- Client Info -->
         <table class="table table-sm table-condensed">
           <colgroup>
@@ -253,7 +257,7 @@
   <!-- ALERTS -->
   <tal:render condition="python:True">
     <div class="row section-alerts no-gutters">
-      <div class="w-100 mb-2">
+      <div class="w-100">
         <tal:model repeat="model collection">
           <div class="alert alert-danger" tal:condition="model/is_invalid">
             <h2 class="alert-heading"><span tal:replace="model/getId"/></h2>
@@ -556,14 +560,19 @@
                   tal:repeat="attachment chunk">
                 <figure class="figure">
                   <img class="figure-img img-fluid"
-                       tal:attributes="src string:${attachment/absolute_url}/AttachmentFile;
-                              style python:len(attachments)==1 and 'max-width:%.2fmm' % (float(content_width))"/>
+                       tal:attributes="src string:${attachment/absolute_url}/AttachmentFile;"/>
                   <figcaption class="figure-caption pt-2">
-                    <div i18n:translate="">
-                      Attachment for
-                      <span tal:replace="attachment/getTextTitle|model/getId"/>
+                    <div class="att_for">
+                      <span i18n:translate="">Attachment for</span>
+                      <span tal:content="attachment/getTextTitle|model/getId"/>
                     </div>
-                    <span tal:content="attachment/AttachmentKeys"/>
+                    <div class="att_keys">
+                      <span tal:content="attachment/AttachmentKeys"/>
+                    </div>
+                    <div class="att_filename">
+                      <span i18n:translate="">Filename:</span>
+                      <span tal:content="attachment/AttachmentFile/filename"/>
+                    </div>
                   </figcaption>
                 </figure>
               </td>

--- a/src/senaite/impress/templates/reports/MultiDefaultByColumn.pt
+++ b/src/senaite/impress/templates/reports/MultiDefaultByColumn.pt
@@ -1,6 +1,7 @@
 <tal:report
   i18n:domain="senaite.impress"
   define="collection python:view.collection;
+          laboratory view/laboratory;
           accredited_symbol string:★;
           outofrange_symbol string:⚠;
           report_options python:options.get('report_options', {});

--- a/src/senaite/impress/templates/reports/MultiDefaultByColumn.pt
+++ b/src/senaite/impress/templates/reports/MultiDefaultByColumn.pt
@@ -44,7 +44,7 @@
 
   <tal:css define="footer_text python:view.get_footer_text();">
     <style type="text/css">
-     .report * { font: 9pt Arial, Verdana, sans-serif; }
+     .report * { font: 9pt; }
      .report h1 { font-size: 140%; }
      .report h2 { font-size: 120%; }
      .report h3 { font-size: 110%; }
@@ -90,6 +90,10 @@
        max-width: <tal:t replace="python:'{:.2f}mm'.format(cw / attachments_per_row)"/>;
        max-height: <tal:t replace="python:'{:.2f}mm'.format(ch * 0.75)"/>;
      }
+     .report .section-resultsinterpretation img {
+       max-width: <tal:t replace="python:'{:.2f}mm'.format(cw)"/>;
+       max-height: <tal:t replace="python:'{:.2f}mm'.format(ch * 0.75)"/>;
+     }
      </tal:block>
      @page {
        <tal:footer condition="footer_text">
@@ -120,7 +124,7 @@
   <tal:render condition="python:True">
     <div class="row section-header no-gutters">
       <!-- Header Table -->
-      <div class="col-sm-12 mb-2">
+      <div class="w-100 mb-2">
         <table class="w-100 mb-0 noborder">
           <colgroup>
             <col style="width:50%"/>
@@ -149,7 +153,7 @@
                       samples python:map(lambda m: m.Sample, collection);">
 
     <div class="row section-info no-gutters">
-      <div class="col-sm-12">
+      <div class="w-100">
         <!-- Client Info -->
         <table class="table table-sm table-condensed">
           <colgroup>
@@ -303,7 +307,7 @@
   <!-- ALERTS -->
   <tal:render condition="python:True">
     <div class="row section-alerts no-gutters">
-      <div class="w-100 mb-2">
+      <div class="w-100">
         <tal:model repeat="model collection">
           <div class="alert alert-danger" tal:condition="model/is_invalid">
             <h2 class="alert-heading"><span tal:replace="model/getId"/></h2>
@@ -469,14 +473,19 @@
                   tal:repeat="attachment chunk">
                 <figure class="figure">
                   <img class="figure-img img-fluid"
-                       tal:attributes="src string:${attachment/absolute_url}/AttachmentFile;
-                              style python:len(attachments)==1 and 'max-width:%.2fmm' % (float(content_width))"/>
+                       tal:attributes="src string:${attachment/absolute_url}/AttachmentFile;"/>
                   <figcaption class="figure-caption pt-2">
-                    <div i18n:translate="">
-                      Attachment for
-                      <span tal:replace="attachment/getTextTitle|model/getId"/>
+                    <div class="att_for">
+                      <span i18n:translate="">Attachment for</span>
+                      <span tal:content="attachment/getTextTitle|model/getId"/>
                     </div>
-                    <span tal:content="attachment/AttachmentKeys"/>
+                    <div class="att_keys">
+                      <span tal:content="attachment/AttachmentKeys"/>
+                    </div>
+                    <div class="att_filename">
+                      <span i18n:translate="">Filename:</span>
+                      <span tal:content="attachment/AttachmentFile/filename"/>
+                    </div>
                   </figcaption>
                 </figure>
               </td>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR updates the markup/style to better handle large images in attachments/results interpretation

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
