### PR TITLE
Fix PDF storage in primary AR when "Store Multi-Report PDFs Individually" option is turned off.

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,7 +1,7 @@
 1.1.1 (unreleased)
 ------------------
 
-- no changes yet
+- #48: Fix PDF storage in primary AR when "Store Multi-Report PDFs Individually" option is turned off
 
 
 1.1.0 (2018-10-04)

--- a/src/senaite/impress/ajax.py
+++ b/src/senaite/impress/ajax.py
@@ -231,7 +231,8 @@ class AjaxPublishView(PublishView):
             reports = []
 
             # fetch the objects rendered in the report by their UID
-            for uid in uids:
+            # N.B. we use the reversed order to have the primary AR first
+            for uid in reversed(uids):
                 obj = api.get_object_by_uid(uid, None)
                 if obj is None:
                     logger.warn("!!!No object found for UID {}!!!".format(uid))


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the PDF storage to the primary AR when the option "Store Multi-Report PDFs Individually" is turned off.

## Current behavior before PR

The last AR was used to store the PDF

## Desired behavior after PR is merged

The primary AR is used to store the PR 

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
