### PR TITLE
Traceback because of getRetested attribute

### DIFF
--- a/src/senaite/impress/analysisrequest/model.py
+++ b/src/senaite/impress/analysisrequest/model.py
@@ -38,10 +38,10 @@ class SuperModel(BaseModel):
         from bika.lims.api.analysis import is_out_of_range
         return is_out_of_range(analysis.instance)[0]
 
-    def is_retested(self, analysis):
-        """Check if the analysis is retested
+    def is_retest(self, analysis):
+        """Check if the analysis is a retest
         """
-        return analysis.getRetested()
+        return analysis.isRetest()
 
     def get_workflow_by_id(self, wfid):
         """Returns a workflow by ID

--- a/src/senaite/impress/templates/reports/Default.pt
+++ b/src/senaite/impress/templates/reports/Default.pt
@@ -447,7 +447,7 @@
                     <td class="specs">
                       <span tal:condition="analysis/Uncertainty"
                             tal:content="structure python:model.get_formatted_uncertainty(analysis)"></span>
-                      <span tal:content="python:'(RT)' if model.is_retested(analysis) else ''"></span>
+                      <span tal:content="python:'(RT)' if model.is_retest(analysis) else ''"></span>
                       <span tal:content="python:model.get_formatted_specs(analysis)">50 - 60</span>
                     </td>
                     <td class="text-center align-middle">

--- a/src/senaite/impress/templates/reports/MultiDefault.pt
+++ b/src/senaite/impress/templates/reports/MultiDefault.pt
@@ -461,7 +461,7 @@
                       <td class="specs">
                         <span tal:condition="analysis/Uncertainty"
                               tal:content="structure python:model.get_formatted_uncertainty(analysis)"></span>
-                        <span tal:content="python:'(RT)' if model.is_retested(analysis) else ''"></span>
+                        <span tal:content="python:'(RT)' if model.is_retest(analysis) else ''"></span>
                         <span tal:content="python:model.get_formatted_specs(analysis)">50 - 60</span>
                       </td>
                       <td class="text-center align-middle">


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Traceback when rendering the report with `senaite.core` >=1.3.0

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module senaite.impress.decorators, line 41, in decorator
  Module senaite.impress.ajax, line 64, in __call__
  Module senaite.impress.ajax, line 175, in ajax_render_reports
  Module senaite.impress.publishview, line 189, in render_multi_report
  Module senaite.impress.publishview, line 306, in read_template
  Module Products.Five.browser.pagetemplatefile, line 59, in __call__
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module five.pt.engine, line 98, in __call__
  Module z3c.pt.pagetemplate, line 158, in render
  Module chameleon.zpt.template, line 297, in render
  Module chameleon.template, line 191, in render
  Module chameleon.template, line 171, in render
  Module c294303fcc7a675ae1f8f1e86b516f16.py, line 3834, in render
  Module senaite.impress.analysisrequest.model, line 44, in is_retested
  Module senaite.core.supermodel.model, line 105, in __getattr__
AttributeError: getRetested
```

## Desired behavior after PR is merged

Report gets rendered without traceback.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
