### PR TITLE
Pinned versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,10 +41,11 @@ setup(
     install_requires=[
         "setuptools",
         "senaite.api>=1.2.0",
-        "senaite.core>=1.2.9",
-        "senaite.core.supermodel>=1.0.0",
+        "senaite.core>=1.3.0",
+        "senaite.core.supermodel>=1.1.0",
         "beautifulsoup4",
         "archetypes.schemaextender",
+        "WeasyPrint==0.42.3",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Pin versions

## Current behavior before PR

No version pinnings

## Desired behavior after PR is merged

- Pinned version of `senaite.core` >= 1.3.0
- Pinned version of `WeasyPrint` == 0.42.3
- Pinned version of `senaite.core.supermodel` >= 1.1.0 

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
