### PR TITLE
Use most recent AR as primary storage

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.1.1 (unreleased)
 ------------------
 
+- #52: Use the most recent AR as the primary storage
 - #48: Fix PDF storage in primary AR when "Store Multi-Report PDFs Individually" option is turned off
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR supersedes https://github.com/senaite/senaite.impress/pull/48

The issue here is that the primary AR for storage was determined by the order in which the ARs appear in the report. This differs depending on the template, e.g. the primary appears on top (first position) for multi-reports, but on the most right (last  position) for multi-by-column templates.

## Current behavior before PR

Primary AR determined by the order in which they appear in the Report.

## Desired behavior after PR is merged

Primary AR is always the most recent one depending on the created date

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
