### PR TITLE
Integration with senaite.core v1.3

### DIFF
--- a/src/senaite/impress/templates/reports/Default.pt
+++ b/src/senaite/impress/templates/reports/Default.pt
@@ -273,8 +273,7 @@
 
   <!-- SUMMARY -->
   <tal:render condition="python:True"
-              define="sample model/Sample;
-                      client model/Client;
+              define="client model/Client;
                       batch model/Batch;
                       reporter python:view.current_user;
                       specification model/Specification;
@@ -297,18 +296,10 @@
         <h1 i18n:translate="">Summary</h1>
         <table class="table table-sm table-condensed">
           <tr>
-            <td style="width:20%" class="label" i18n:translate="">Request ID</td>
+            <td style="width:20%" class="label" i18n:translate="">Sample ID</td>
             <td>
               <a tal:content="model/getId"
                  tal:attributes="href model/absolute_url;">
-              </a>
-            </td>
-          </tr>
-          <tr>
-            <td class="label" i18n:translate="">Sample ID</td>
-            <td>
-              <a tal:content="sample/getId"
-                 tal:attributes="href sample/absolute_url">
               </a>
             </td>
           </tr>
@@ -337,7 +328,7 @@
           </tr>
           <tr>
             <td class="label" i18n:translate="">Sample Type</td>
-            <td tal:content="sample/SampleType/title|nothing"></td>
+            <td tal:content="model/SampleType/title|nothing"></td>
           </tr>
           <tr>
             <td class="label" i18n:translate="">Specification</td>

--- a/src/senaite/impress/templates/reports/MultiDefault.pt
+++ b/src/senaite/impress/templates/reports/MultiDefault.pt
@@ -282,7 +282,6 @@
   <!-- SUMMARY (First AR is primary for the data) -->
   <tal:render condition="python:len(collection) > 0"
               define="model python:collection[0];
-                      sample model/Sample;
                       batch model/Batch;
                       client model/Client;
                       reporter python:view.current_user;
@@ -308,18 +307,10 @@
 
         <table class="table table-sm table-condensed">
           <tr>
-            <td style="width:20%" class="label" i18n:translate="">Request ID</td>
+            <td style="width:20%" class="label" i18n:translate="">Sample ID</td>
             <td>
               <a tal:content="model/getId"
                  tal:attributes="href model/absolute_url;">
-              </a>
-            </td>
-          </tr>
-          <tr>
-            <td class="label" i18n:translate="">Sample ID</td>
-            <td>
-              <a tal:content="sample/id"
-                 tal:attributes="href sample/absolute_url">
               </a>
             </td>
           </tr>
@@ -348,7 +339,7 @@
           </tr>
           <tr>
             <td class="label" i18n:translate="">Sample Type</td>
-            <td tal:content="sample/SampleType/title|nothing"></td>
+            <td tal:content="model/SampleType/title|nothing"></td>
           </tr>
           <tr>
             <td class="label" i18n:translate="">Specification</td>

--- a/src/senaite/impress/templates/reports/MultiDefaultByColumn.pt
+++ b/src/senaite/impress/templates/reports/MultiDefaultByColumn.pt
@@ -149,8 +149,7 @@
 
   <!-- INFO -->
   <tal:render condition="python:len(collection)>0"
-              define="primarymodel python:collection[0];
-                      samples python:map(lambda m: m.Sample, collection);">
+              define="primarymodel python:collection[0];">
 
     <div class="row section-info no-gutters">
       <div class="w-100">
@@ -213,7 +212,7 @@
                 <tr>
                   <td class="label" i18n:translate="">Sample Type</td>
                   <td class="field">
-                    <tal:sampletype define="sampletypes python:map(lambda m: m.SampleTypeTitle, samples)"
+                    <tal:sampletype define="sampletypes python:map(lambda m: m.SampleTypeTitle, collection)"
                                     repeat="sampletype python:view.uniquify_items(sampletypes)">
                       <div tal:content="sampletype"/>
                     </tal:sampletype>
@@ -223,7 +222,7 @@
                 <tr>
                   <td class="label" i18n:translate="">Sample Point</td>
                   <td class="field">
-                    <tal:samplepoint define="samplepoints python:map(lambda m: m.SamplePointTitle, samples)"
+                    <tal:samplepoint define="samplepoints python:map(lambda m: m.SamplePointTitle, collection)"
                                      repeat="samplepoint python:view.uniquify_items(samplepoints)">
                       <div tal:content="samplepoint"/>
                     </tal:samplepoint>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request is meant to include all changes required to make `senaite.impress` compatible with `senaite.core` v1.3.0.

- Unbount reports from Sample portal type. 
  Requirement: [#1180 Sample clenaup](https://github.com/senaite/senaite.core/pull/1180)

## Current behavior before PR

`senaite.impress` not compatible with `senaite.core` v1.3.0

## Desired behavior after PR is merged

`senaite.impress` compatible with `senaite.core` v1.3.0

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
