### PR TITLE
Rejected AS are shown in the PDF Report

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.2.0 (unreleased)
 ------------------
 
+- #64: Fix Rejected AS are shown in the PDF Report
 - #62: Better error message handling
 - #57: SENAITE CORE integration
 - #52: Use the most recent AR as the primary storage

--- a/src/senaite/impress/analysisrequest/reportview.py
+++ b/src/senaite/impress/analysisrequest/reportview.py
@@ -134,7 +134,7 @@ class ReportView(Base):
     def get_analyses_by(self, model_or_collection,
                         title=None, service_title=None,
                         poc=None, category=None,
-                        hidden=False, retracted=False):
+                        hidden=False, retracted=False, rejected=False):
         """Returns a sorted list of Analyses for the given POC which are in the
         given Category
         """
@@ -157,6 +157,10 @@ class ReportView(Base):
             def is_not_retracted(analysis):
                 return analysis.review_state != "retracted"
             analyses = filter(is_not_retracted, analyses)
+        if not rejected:
+            def is_not_rejected(analysis):
+                return analysis.review_state != "rejected"
+            analyses = filter(is_not_rejected, analyses)
         return self.sort_items(analyses)
 
     def get_analyses_by_poc(self, model_or_collection):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

https://github.com/senaite/senaite.impress/issues/64

## Current behavior before PR

By default, rejected analyses are displayed in results reports

## Desired behavior after PR is merged

By default, rejected analyses are not displayed in results reports

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
