### PR TITLE
Fix PublicationPreference Traceback in Default template

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,3 +1,8 @@
+1.2.1 (unreleased)
+------------------
+
+- #66: Fix Publication Preference Traceback with Default template
+
 1.2.0 (2019-03-30)
 ------------------
 

--- a/src/senaite/impress/templates/reports/Default.pt
+++ b/src/senaite/impress/templates/reports/Default.pt
@@ -623,10 +623,6 @@
              tal:condition="confidence_level" i18n:translate="">
           Test results are at a <tal:block replace="confidence_level" i18n:name="lab_confidence"/>% confidence level
         </div>
-        <div class="discreeter-linkage"
-             tal:condition="python:contact and contact.PublicationPreference != '' and 'email' in contact.PublicationPreference" i18n:translate="">
-          Methods of analysis available by clicking on the 'Request' link
-        </div>
       </div>
     </div>
   </tal:render>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Traceback is rised when Default template is selected in report preview.

https://github.com/senaite/senaite.impress/issues/66

## Current behavior before PR

```
Error: PublicationPreference

 - Expression: "python:contact and contact.PublicationPreference != '' and 'email' in contact.PublicationPreference"
 - Filename:   ... impress/src/senaite/impress/templates/reports/Default.pt
 - Location:   (line 627: col 28)
 - Source:     ... python:contact and contact.PublicationPreference != '' and 'email' in contact.PublicationPreference ...
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Arguments:  page_width: 210.0
               request: <instance - at 0x7f99e1661f38>
               laboratory: <SuperModel - at 0x7f99de5d3710>
               content_height: 257.0
               container: <ImplicitAcquisitionWrapper senaite at 0x7f99e1efdd20>
               wrapped_repeat: <SafeMapping - at 0x7f99de41ce10>
               accredited_symbol: ★
               contact: <SuperModel - at 0x7f99dfa389d0>
               traverse_subpath: <list - at 0x7f99df62a6c8>
               content_width: 170.0
               template: <ViewPageTemplateFile - at 0x7f99df5fac90>
               report_options: {...} (1)
               translate: <function translate at 0x7f99df2d5a28>
               repeat: {...} (0)
               views: <ViewMapper - at 0x7f99df5fa3d0>
               args: <tuple - at 0x7f99fde96050>
               here: <ImplicitAcquisitionWrapper senaite at 0x7f99e1efdd20>
               attachments_per_row: 2
               user: <ImplicitAcquisitionWrapper - at 0x7f99e1ab15a0>
               nothing: <NoneType - at 0x935be0>
               page_height: 297.0
               footer: 
               default: <object - at 0x7f99fddaf4f0>
               modules: <instance - at 0x7f99f6331290>
               client: <SuperModel - at 0x7f99dfa38cd0>
               outofrange_symbol: ⚠
               context: <ImplicitAcquisitionWrapper senaite at 0x7f99e1efdd20>
               model: <SuperModel - at 0x7f99df84a450>
               target_language: en
               root: <ImplicitAcquisitionWrapper Zope at 0x7f99df5f4fa0>
               options: {...} (12)
               loop: {...} (4)
               view: <LocationProxy None at 0x7f99df1b5128>
```

## Desired behavior after PR is merged

Report template is rendered correctly without traceback

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
