### PR TITLE
Conflict safe concurrent report creation

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.2.1 (unreleased)
 ------------------
 
+- #75: Conflict safe concurrent report creation
 - #71: Implemented storage adapter
 - #73: Extend README wrt 'Reports in external packages'
 - #66: Fix Publication Preference Traceback with Default template

--- a/src/senaite/impress/decorators.py
+++ b/src/senaite/impress/decorators.py
@@ -29,10 +29,10 @@ from senaite.impress import logger
 from zope.component import queryAdapter
 
 
-def synchronized(max_connections=2):
+def synchronized(max_connections=2, verbose=0):
     """Synchronize function call via semaphore
     """
-    semaphore = threading.BoundedSemaphore(max_connections, verbose=1)
+    semaphore = threading.BoundedSemaphore(max_connections, verbose=verbose)
 
     def inner(func):
         logger.debug("Semaphore for {} -> {}".format(func, semaphore))

--- a/src/senaite/impress/decorators.py
+++ b/src/senaite/impress/decorators.py
@@ -29,23 +29,27 @@ from senaite.impress import logger
 from zope.component import queryAdapter
 
 
-def synchronized(func, max_connections=2):
+def synchronized(max_connections=2):
     """Synchronize function call via semaphore
     """
-    semaphore = threading.BoundedSemaphore(max_connections)
-    logger.debug("Semaphore for {} -> {}".format(func, semaphore))
+    semaphore = threading.BoundedSemaphore(max_connections, verbose=1)
 
-    def decorator(*args, **kwargs):
-        try:
-            logger.info("==> {}::Acquire Semaphore ...".format(
-                func.__name__))
-            semaphore.acquire()
-            return func(*args, **kwargs)
-        finally:
-            logger.info("<== {}::Release Semaphore ...".format(
-                func.__name__))
-            semaphore.release()
-    return decorator
+    def inner(func):
+        logger.debug("Semaphore for {} -> {}".format(func, semaphore))
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                logger.info("==> {}::Acquire Semaphore ...".format(
+                    func.__name__))
+                semaphore.acquire()
+                return func(*args, **kwargs)
+            finally:
+                logger.info("<== {}::Release Semaphore ...".format(
+                    func.__name__))
+                semaphore.release()
+
+        return wrapper
+    return inner
 
 
 def returns_json(func):

--- a/src/senaite/impress/publisher.py
+++ b/src/senaite/impress/publisher.py
@@ -143,7 +143,7 @@ class Publisher(object):
                     .format(end-start, len(document.pages)))
         return document
 
-    @synchronized
+    @synchronized(max_connections=2)
     def url_fetcher(self, url):
         """Fetches internal URLs by path and not via an external request.
 

--- a/src/senaite/impress/storage.py
+++ b/src/senaite/impress/storage.py
@@ -70,13 +70,16 @@ class PdfReportStorageAdapter(object):
         :param parent: parent object where to create the report inside
         :returns: ARReport
         """
-        report = api.create(parent, "ARReport")
-        report.edit(
-            title=api.get_id(report),
+        report = api.create(
+            parent,
+            "ARReport",
             AnalysisRequest=api.get_uid(parent),
             Pdf=pdf,
             Html=html,
             ContainedAnalysisRequests=uids,
             Metadata=metadata)
+
+        # set the generated ID as the title
+        report.setTitle(report.getId())
 
         return report


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR improves the report creation process for simultaneous publications.

## Current behavior before PR

Conflict errors occur for simultaneous report publications. E.g. pressing the "Save" button for 20 rendered previews quickly one-by-one.

## Desired behavior after PR is merged

No conflict errors occur for simultaneous report publications

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
