### PR TITLE
Do not display Analyses marked for InternalUse in results report

### DIFF
--- a/src/senaite/impress/analysisrequest/reportview.py
+++ b/src/senaite/impress/analysisrequest/reportview.py
@@ -27,6 +27,7 @@ from string import Template
 
 import DateTime
 from bika.lims import POINTS_OF_CAPTURE
+from bika.lims.interfaces import IInternalUse
 from bika.lims.workflow import getTransitionDate
 from Products.CMFPlone.i18nl10n import ulocalized_time
 from Products.CMFPlone.utils import safe_unicode
@@ -143,6 +144,9 @@ class ReportView(Base):
         """
         collection = self.to_list(model_or_collection)
         analyses = chain(*map(lambda m: m.Analyses, collection))
+        # Boil out analyses meant to be used for internal use only
+        analyses = filter(lambda an: not IInternalUse.providedBy(an.instance),
+                          analyses)
         return self.sort_items(analyses)
 
     def get_analyses_by(self, model_or_collection,


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Depends on: https://github.com/senaite/senaite.core/pull/1391

With this Pull Request, analyses marked with `IInternalUse` are not displayed in results reports. Consider the following scenario:
- Client contact creates a new Sample
- Lab received the Sample and create two partitions
- One of the partitions is labelled for internal use (with additional analyses or for storage, etc.)

Without this Pull Request, when LabMan generates a report for the Primary Sample, analyses from the sample labeled as for internal use will be displayed.

## Current behavior before PR

All analyses of a given Sample are displayed in results report

## Desired behavior after PR is merged

Analyses marked with "IInternalUse" interface are not displayed in results report

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
