### PR TITLE
Fix template error on missing lab address data

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,7 +1,7 @@
 1.2.2 (unreleased)
 ------------------
 
-- no changes yet
+- #78: Fix template error on missing lab address data
 
 
 1.2.1 (2019-07-01)

--- a/src/senaite/impress/templates/reports/Default.pt
+++ b/src/senaite/impress/templates/reports/Default.pt
@@ -646,22 +646,22 @@
         <tr>
           <td>
             <div>
-              <strong tal:content="laboratory/Name">Lab Name</strong>
-              • <span tal:content="laboratory/PhysicalAddress/address">Lab Street and Number</span>
-              • <span tal:content="laboratory/PhysicalAddress/zip">Lab ZIP</span>
-                <span tal:content="laboratory/PhysicalAddress/city">Lab City</span>
-              • <span tal:content="laboratory/PhysicalAddress/country">Lab Country</span>
+              <strong tal:content="laboratory/Name|nothing">Lab Name</strong>
+              • <span tal:content="laboratory/PhysicalAddress/address|nothing">Lab Street and Number</span>
+              • <span tal:content="laboratory/PhysicalAddress/zip|nothing">Lab ZIP</span>
+                <span tal:content="laboratory/PhysicalAddress/city|nothing">Lab City</span>
+              • <span tal:content="laboratory/PhysicalAddress/country|nothing">Lab Country</span>
             </div>
             <div>
               <span i18n:translate="">Phone</span>:
-              <span tal:content="laboratory/Phone">Lab Phone Number</span>
+              <span tal:content="laboratory/Phone|nothing">Lab Phone Number</span>
               • <span i18n:translate="">Fax</span>:
-                <span tal:content="laboratory/Fax">Lab Fax Number</span>
-              • <a href="#" tal:attributes="href string:mailto:${laboratory/EmailAddress}">
-                <span tal:content="laboratory/EmailAddress">Lab Email</span>
+                <span tal:content="laboratory/Fax|nothing">Lab Fax Number</span>
+              • <a href="#" tal:attributes="href string:mailto:${laboratory/EmailAddress|nothing}">
+                <span tal:content="laboratory/EmailAddress|nothing">Lab Email</span>
               </a>
-              • <a href="#" tal:attributes="href laboratory/LabURL">
-                <span tal:content="laboratory/LabURL">Lab URL</span>
+              • <a href="#" tal:attributes="href laboratory/LabURL|nothing">
+                <span tal:content="laboratory/LabURL|nothing">Lab URL</span>
               </a>
             </div>
           </td>

--- a/src/senaite/impress/templates/reports/MultiDefault.pt
+++ b/src/senaite/impress/templates/reports/MultiDefault.pt
@@ -674,22 +674,22 @@
         <tr>
           <td>
             <div>
-              <strong tal:content="laboratory/Name">Lab Name</strong>
-              • <span tal:content="laboratory/PhysicalAddress/address">Lab Street and Number</span>
-              • <span tal:content="laboratory/PhysicalAddress/zip">Lab ZIP</span>
-                <span tal:content="laboratory/PhysicalAddress/city">Lab City</span>
-              • <span tal:content="laboratory/PhysicalAddress/country">Lab Country</span>
+              <strong tal:content="laboratory/Name|nothing">Lab Name</strong>
+              • <span tal:content="laboratory/PhysicalAddress/address|nothing">Lab Street and Number</span>
+              • <span tal:content="laboratory/PhysicalAddress/zip|nothing">Lab ZIP</span>
+                <span tal:content="laboratory/PhysicalAddress/city|nothing">Lab City</span>
+              • <span tal:content="laboratory/PhysicalAddress/country|nothing">Lab Country</span>
             </div>
             <div>
               <span i18n:translate="">Phone</span>:
-              <span tal:content="laboratory/Phone">Lab Phone Number</span>
+              <span tal:content="laboratory/Phone|nothing">Lab Phone Number</span>
               • <span i18n:translate="">Fax</span>:
-                <span tal:content="laboratory/Fax">Lab Fax Number</span>
-              • <a href="#" tal:attributes="href string:mailto:${laboratory/EmailAddress}">
-                <span tal:content="laboratory/EmailAddress">Lab Email</span>
+                <span tal:content="laboratory/Fax|nothing">Lab Fax Number</span>
+              • <a href="#" tal:attributes="href string:mailto:${laboratory/EmailAddress|nothing}">
+                <span tal:content="laboratory/EmailAddress|nothing">Lab Email</span>
               </a>
-              • <a href="#" tal:attributes="href laboratory/LabURL">
-                <span tal:content="laboratory/LabURL">Lab URL</span>
+              • <a href="#" tal:attributes="href laboratory/LabURL|nothing">
+                <span tal:content="laboratory/LabURL|nothing">Lab URL</span>
               </a>
             </div>
           </td>

--- a/src/senaite/impress/templates/reports/MultiDefaultByColumn.pt
+++ b/src/senaite/impress/templates/reports/MultiDefaultByColumn.pt
@@ -595,22 +595,22 @@
         <tr>
           <td>
             <div>
-              <strong tal:content="laboratory/Name">Lab Name</strong>
-              • <span tal:content="laboratory/PhysicalAddress/address">Lab Street and Number</span>
-              • <span tal:content="laboratory/PhysicalAddress/zip">Lab ZIP</span>
-                <span tal:content="laboratory/PhysicalAddress/city">Lab City</span>
-              • <span tal:content="laboratory/PhysicalAddress/country">Lab Country</span>
+              <strong tal:content="laboratory/Name|nothing">Lab Name</strong>
+              • <span tal:content="laboratory/PhysicalAddress/address|nothing">Lab Street and Number</span>
+              • <span tal:content="laboratory/PhysicalAddress/zip|nothing">Lab ZIP</span>
+                <span tal:content="laboratory/PhysicalAddress/city|nothing">Lab City</span>
+              • <span tal:content="laboratory/PhysicalAddress/country|nothing">Lab Country</span>
             </div>
             <div>
               <span i18n:translate="">Phone</span>:
-              <span tal:content="laboratory/Phone">Lab Phone Number</span>
+              <span tal:content="laboratory/Phone|nothing">Lab Phone Number</span>
               • <span i18n:translate="">Fax</span>:
-                <span tal:content="laboratory/Fax">Lab Fax Number</span>
-              • <a href="#" tal:attributes="href string:mailto:${laboratory/EmailAddress}">
-                <span tal:content="laboratory/EmailAddress">Lab Email</span>
+                <span tal:content="laboratory/Fax|nothing">Lab Fax Number</span>
+              • <a href="#" tal:attributes="href string:mailto:${laboratory/EmailAddress|nothing}">
+                <span tal:content="laboratory/EmailAddress|nothing">Lab Email</span>
               </a>
-              • <a href="#" tal:attributes="href laboratory/LabURL">
-                <span tal:content="laboratory/LabURL">Lab URL</span>
+              • <a href="#" tal:attributes="href laboratory/LabURL|nothing">
+                <span tal:content="laboratory/LabURL|nothing">Lab URL</span>
               </a>
             </div>
           </td>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Fix error in report footer when no lab address is given.

## Current behavior before PR

<img width="1175" alt="SENAITE IMPRESS 2019-09-18 22-54-23" src="https://user-images.githubusercontent.com/713193/65185314-95ba1e00-da67-11e9-991f-c9a242f3d828.png">

## Desired behavior after PR is merged

Templates are displayed correctly, even when some lab data is missing

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
