### PR TITLE
Use senaite.core.api instead of senaite.api

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -44,7 +44,6 @@ develop = .
 [sources]
 senaite.core = git git://github.com/senaite/senaite.core.git pushurl=git@github.com:senaite/senaite.core.git branch=master
 senaite.lims = git git://github.com/senaite/senaite.lims.git pushurl=git@github.com:senaite/senaite.lims.git branch=master
-senaite.api = git git://github.com/senaite/senaite.api.git pushurl=git@github.com:senaite/senaite.api.git branch=master
 senaite.core.supermodel = git git://github.com/senaite/senaite.core.supermodel.git pushurl=git@github.com:senaite/senaite.core.supermodel.git branch=master
 senaite.core.listing = git git://github.com/senaite/senaite.core.listing.git pushurl=git@github.com:senaite/senaite.core.listing.git branch=master
 

--- a/src/senaite/impress/analysisrequest/model.py
+++ b/src/senaite/impress/analysisrequest/model.py
@@ -24,7 +24,7 @@ from bika.lims.utils import format_supsub
 from bika.lims.utils import formatDecimalMark
 from bika.lims.utils import to_utf8
 from bika.lims.utils.analysis import format_uncertainty
-from senaite import api
+from bika.lims import api
 from senaite.core.supermodel import SuperModel as BaseModel
 from senaite.impress import logger
 from senaite.impress.decorators import returns_super_model

--- a/src/senaite/impress/analysisrequest/reportview.py
+++ b/src/senaite/impress/analysisrequest/reportview.py
@@ -31,7 +31,7 @@ from bika.lims.interfaces import IInternalUse
 from bika.lims.workflow import getTransitionDate
 from Products.CMFPlone.i18nl10n import ulocalized_time
 from Products.CMFPlone.utils import safe_unicode
-from senaite import api
+from bika.lims import api
 from senaite.core.supermodel.interfaces import ISuperModel
 from senaite.impress import logger
 from senaite.impress.decorators import returns_super_model

--- a/src/senaite/impress/decorators.py
+++ b/src/senaite/impress/decorators.py
@@ -23,7 +23,7 @@ import threading
 import time
 from functools import wraps
 
-from senaite import api
+from bika.lims import api
 from senaite.core.supermodel.interfaces import ISuperModel
 from senaite.impress import logger
 from zope.component import queryAdapter

--- a/src/senaite/impress/publisher.py
+++ b/src/senaite/impress/publisher.py
@@ -26,7 +26,7 @@ from string import Template
 
 import bs4
 from plone.subrequest import subrequest
-from senaite import api
+from bika.lims import api
 from senaite.impress import logger
 from senaite.impress.decorators import synchronized
 from senaite.impress.interfaces import IPublisher

--- a/src/senaite/impress/publishview.py
+++ b/src/senaite/impress/publishview.py
@@ -27,7 +27,7 @@ from plone.app.i18n.locales.browser.selector import LanguageSelector
 from plone.resource.utils import iterDirectoriesOfType
 from Products.Five import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from senaite import api
+from bika.lims import api
 from senaite.core.supermodel.interfaces import ISuperModel
 from senaite.impress import logger
 from senaite.impress.config import PAPERFORMATS

--- a/src/senaite/impress/reportview.py
+++ b/src/senaite/impress/reportview.py
@@ -18,7 +18,7 @@
 # Copyright 2018-2019 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from senaite import api
+from bika.lims import api
 from senaite.impress.interfaces import IReportView
 from zope.interface import implements
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes the imports of `senaite.impress`

## Current behavior before PR

Code depends on `senaite.api`

## Desired behavior after PR is merged

Code no longer depends on `senaite.api`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
