### PR TITLE
Fix Date Published is empty on MultiDefault report

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,7 +1,7 @@
 1.2.2 (unreleased)
 ------------------
 
-- #68: Fix empty Date Published on Multi Default report
+- #82: Fix Date Published is empty on MultiDefault report
 - #81: Rebuild JavaScript bundle with new versions
 - #80: Update Bootstrap CSS to version 4.3.1
 - #79: Use senaite.core.api instead of senaite.api

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.2.2 (unreleased)
 ------------------
 
+- #68: Fix empty Date Published on Multi Default report
 - #81: Rebuild JavaScript bundle with new versions
 - #80: Update Bootstrap CSS to version 4.3.1
 - #79: Use senaite.core.api instead of senaite.api

--- a/src/senaite/impress/templates/reports/MultiDefault.pt
+++ b/src/senaite/impress/templates/reports/MultiDefault.pt
@@ -342,7 +342,7 @@
           </tr>
           <tr>
             <td class="label" i18n:translate="">Date Published</td>
-            <td tal:content="python:view.to_localized_time(model.DatePublished)"></td>
+            <td tal:content="python:view.to_localized_time(view.timestamp)"></td>
           </tr>
           <tr tal:condition="reporter">
             <td class="label" i18n:translate="">Published by</td>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.impress/issues/68

## Current behavior before PR

Date published empty in MultiDefault report 

## Desired behavior after PR is merged

Date published uses current timestamp in MultiDefault report 

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
