### PR TITLE
Fix HTML encoding for PDF printing

### DIFF
--- a/src/senaite/impress/publishview.py
+++ b/src/senaite/impress/publishview.py
@@ -103,6 +103,7 @@ class PublishView(BrowserView):
         # NOTE: It might also contain multiple reports!
         html = form.get("html", "")
         # convert to unicode
+        # https://github.com/senaite/senaite.impress/pull/93
         html = api.safe_unicode(html)
         # get the selected template
         template = form.get("template")

--- a/src/senaite/impress/publishview.py
+++ b/src/senaite/impress/publishview.py
@@ -102,6 +102,8 @@ class PublishView(BrowserView):
         # eventually extended by JavaScript, e.g. Barcodes or Graphs added etc.
         # NOTE: It might also contain multiple reports!
         html = form.get("html", "")
+        # convert to unicode
+        html = api.safe_unicode(html)
         # get the selected template
         template = form.get("template")
         # get the selected paperformat


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an occasional encoding issue when printing (via `printview` PDF button) a report that contains unicode characters, e.g. german umlauts `äöü`.

## Current behavior before PR

Unicode characters are not printed correctly in the PDF

## Desired behavior after PR is merged

Unicode characters are printed correctly in the PDF

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
